### PR TITLE
disabled submit if no patient select

### DIFF
--- a/src/main/webapp/WEB-INF/templates/authorization.html
+++ b/src/main/webapp/WEB-INF/templates/authorization.html
@@ -11,7 +11,7 @@
     <link href="css/site.css" rel="stylesheet">
 </head>
 <body>
-	<div th:replace="tmpl-banner :: banner"></div>
+	<div id="banner" style="display: none"><div th:replace="tmpl-banner :: banner"></div></div>
 	
 	<br>
 	<br>

--- a/src/main/webapp/js/authorize.js
+++ b/src/main/webapp/js/authorize.js
@@ -54,6 +54,7 @@ window.mitre.fhirreferenceserver.authorize = {
             return;
         }
         
+        $('#banner').show();
         $('#pageContent').show();
 
         let state = urlParams.get('state') || '';
@@ -115,6 +116,7 @@ window.mitre.fhirreferenceserver.authorize = {
     
     showErrorMessage(errorMessage)
     {
+        $('#banner').show();
         $('#errorMessage').html(errorMessage).show();
     }
 }


### PR DESCRIPTION
# Summary
Currently if submit is pressed before redirecting to the patient picker, it will submit without a patient. Needed to prevent this from happening.

## New behavior
Now the submit button is disabled when no patient parameter is provided.

## Code changes

## Testing guidance
This is difficult to see this because the redirect will happen too quickly. So to test, add a break point in the browser on line 53 of authorize.js to confirm that the button is disabled.
