### PR TITLE
Add -q (quiet) flag to mvn build in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM maven:3.6-jdk-11 AS mavenbuild
 COPY pom.xml /home/app/
 COPY src /home/app/src
 COPY config /home/app/config
-RUN mvn -f /home/app/pom.xml package
+RUN mvn -q -f /home/app/pom.xml package
 
 FROM jetty:9.4-jre11
 


### PR DESCRIPTION
This was generating huge log files for me and slowing down my build considerably.  I'm not sure if this is normal or not, but I see no harm in hiding all but important messages here.