### PR TITLE
FI-1499 Sub Claim

### DIFF
--- a/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
+++ b/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
@@ -17,6 +17,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.UUID;
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import org.hl7.fhir.r4.model.Bundle;
@@ -373,9 +374,11 @@ public class AuthorizationController {
       calendar.set(Calendar.YEAR, calendar.get(Calendar.YEAR) + 1);
       Date expiresAt = calendar.getTime();
 
+      String sub = UUID.randomUUID().toString();
+
       Algorithm algorithm = Algorithm.RSA256(publicKey, privateKey);
       String token = JWT.create().withIssuer(FhirReferenceServerUtils.getFhirServerBaseUrl(request))
-          .withSubject("subject").withAudience(clientId).withExpiresAt(expiresAt).withIssuedAt(issuedAt)
+          .withSubject(sub).withAudience(clientId).withExpiresAt(expiresAt).withIssuedAt(issuedAt)
           .withClaim("fhirUser", fhirUserUrl).sign(algorithm);
 
       return token;

--- a/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
+++ b/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
@@ -375,7 +375,7 @@ public class AuthorizationController {
 
       Algorithm algorithm = Algorithm.RSA256(publicKey, privateKey);
       String token = JWT.create().withIssuer(FhirReferenceServerUtils.getFhirServerBaseUrl(request))
-          .withSubject("").withAudience(clientId).withExpiresAt(expiresAt).withIssuedAt(issuedAt)
+          .withSubject("subject").withAudience(clientId).withExpiresAt(expiresAt).withIssuedAt(issuedAt)
           .withClaim("fhirUser", fhirUserUrl).sign(algorithm);
 
       return token;

--- a/src/main/java/org/mitre/fhir/wellknown/WellKnownAuthorizationEndpointController.java
+++ b/src/main/java/org/mitre/fhir/wellknown/WellKnownAuthorizationEndpointController.java
@@ -73,7 +73,7 @@ public class WellKnownAuthorizationEndpointController {
   }
 
   /**
-   * Supports retrieval of the opopenid configuration for authorization and authentication.
+   * Supports retrieval of the openid configuration for authorization and authentication.
    *
    * @param theRequest the incoming HTTP request
    * @return String representing the JSON object of the OpenID configuration

--- a/src/test/java/org/mitre/fhir/authorization/TestAuthorization.java
+++ b/src/test/java/org/mitre/fhir/authorization/TestAuthorization.java
@@ -637,6 +637,7 @@ public class TestAuthorization {
 
     Assert.assertEquals("RS256", decoded.getAlgorithm());
     Assert.assertNotNull(decoded.getClaim("fhirUser"));
+    Assert.assertFalse(decoded.getSubject().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
# Summary
Added the subject identifier claim to the OpenID token. 

## New behavior
See content of **id_token_payload_json**

<img width="1615" alt="Screen Shot 2022-04-26 at 12 04 54 PM" src="https://user-images.githubusercontent.com/37051655/165345675-0b00fa9f-bf69-4e6f-8f98-074d2c183bdc.png">

## Code changes
Simple addition of a subject string. 

## Testing guidance
Run core outside of docker with g10 enabled and see the output of test 1.3.01 to see the sub claim in the OpenID token payload.