### PR TITLE
FI-1660: Prevent Writes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 services:
-  db:    
+  db:
     build:
       context: .
       dockerfile: Dockerfile.database
@@ -20,6 +20,7 @@ services:
     environment:
       - POSTGRES_HOST=db
       - CUSTOM_BEARER_TOKEN=SAMPLE_TOKEN
+      - READ_ONLY=true
     networks:
       - fhirnet
     depends_on:
@@ -27,6 +28,6 @@ services:
 
 networks:
   fhirnet:
-  
+
 volumes:
   fhir-pgdata:

--- a/src/config.properties
+++ b/src/config.properties
@@ -1,1 +1,0 @@
-READ_ONLY=false

--- a/src/config.properties
+++ b/src/config.properties
@@ -1,0 +1,1 @@
+READ_ONLY=false

--- a/src/main/java/org/mitre/fhir/MitreJpaServer.java
+++ b/src/main/java/org/mitre/fhir/MitreJpaServer.java
@@ -15,7 +15,6 @@ import ca.uhn.fhir.rest.server.provider.ResourceProviderFactory;
 import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import javax.servlet.ServletException;
 
-import com.fasterxml.jackson.databind.annotation.JsonAppend;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Meta;
 import org.mitre.fhir.authorization.FakeOauth2AuthorizationInterceptorAdaptor;
@@ -25,8 +24,6 @@ import org.mitre.fhir.bulk.BulkInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.web.context.support.SpringBeanAutowiringSupport;
-import java.io.*;
-import java.util.Properties;
 
 /**
  * MitreJpaServer configures the server.
@@ -48,27 +45,12 @@ public class MitreJpaServer extends RestfulServer {
     SpringBeanAutowiringSupport.processInjectionBasedOnCurrentContext(this);
   }
 
-  public Properties LoadConfig() {
-    Properties prop = new Properties();
-
-    try {
-      FileInputStream propsInput = new FileInputStream("src/config.properties");
-      prop.load(propsInput);
-    } catch (FileNotFoundException e) {
-      e.printStackTrace();
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
-
-    return prop;
-  }
-
   @Override
   protected void initialize() throws ServletException {
     super.initialize();
 
     // Load configuration
-    Properties prop = LoadConfig();
+    Boolean ReadOnly = Boolean.parseBoolean(System.getProperty("READ_ONLY"));
 
     // Setup a FHIR context.
     FhirVersionEnum fhirVersion = FhirVersionEnum.R4;
@@ -138,7 +120,7 @@ public class MitreJpaServer extends RestfulServer {
 
     registerInterceptor(new FakeOauth2AuthorizationInterceptorAdaptor());
 
-    if (Boolean.parseBoolean(prop.getProperty("READ_ONLY"))) {
+    if (ReadOnly) {
       registerInterceptor(new ReadOnlyInterceptor());
     };
 

--- a/src/main/java/org/mitre/fhir/MitreJpaServer.java
+++ b/src/main/java/org/mitre/fhir/MitreJpaServer.java
@@ -49,7 +49,7 @@ public class MitreJpaServer extends RestfulServer {
   protected void initialize() throws ServletException {
     super.initialize();
 
-    // Load configuration
+    // Load ReadOnly var
     Boolean ReadOnly = Boolean.parseBoolean(System.getProperty("READ_ONLY"));
 
     // Setup a FHIR context.

--- a/src/main/java/org/mitre/fhir/MitreJpaServer.java
+++ b/src/main/java/org/mitre/fhir/MitreJpaServer.java
@@ -7,6 +7,7 @@ import ca.uhn.fhir.jpa.api.dao.IFhirSystemDao;
 import ca.uhn.fhir.jpa.provider.TerminologyUploaderProvider;
 import ca.uhn.fhir.jpa.provider.r4.JpaSystemProviderR4;
 import ca.uhn.fhir.jpa.search.DatabaseBackedPagingProvider;
+import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.server.ETagSupportEnum;
 import ca.uhn.fhir.rest.server.RestfulServer;
@@ -33,6 +34,8 @@ import org.springframework.web.context.support.SpringBeanAutowiringSupport;
 
 public class MitreJpaServer extends RestfulServer {
   private static final long serialVersionUID = 1L;
+  private static final String READ_ONLY_ENV_KEY = "READ_ONLY";
+
 
   @Autowired
   protected ISearchParamRegistry searchParamRegistry;
@@ -50,7 +53,10 @@ public class MitreJpaServer extends RestfulServer {
     super.initialize();
 
     // Load ReadOnly var
-    Boolean ReadOnly = Boolean.parseBoolean(System.getProperty("READ_ONLY"));
+    String ReadOnly = System.getenv().get(READ_ONLY_ENV_KEY);
+    if (ReadOnly == null) {
+      ReadOnly = System.getProperty(READ_ONLY_ENV_KEY);
+    }
 
     // Setup a FHIR context.
     FhirVersionEnum fhirVersion = FhirVersionEnum.R4;
@@ -120,7 +126,7 @@ public class MitreJpaServer extends RestfulServer {
 
     registerInterceptor(new FakeOauth2AuthorizationInterceptorAdaptor());
 
-    if (ReadOnly) {
+    if (Boolean.parseBoolean(ReadOnly)) {
       registerInterceptor(new ReadOnlyInterceptor());
     };
 

--- a/src/main/java/org/mitre/fhir/ReadOnlyInterceptor.java
+++ b/src/main/java/org/mitre/fhir/ReadOnlyInterceptor.java
@@ -1,0 +1,31 @@
+package org.mitre.fhir;
+
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.rest.server.exceptions.MethodNotAllowedException;
+import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
+
+import static ca.uhn.fhir.interceptor.api.Pointcut.SERVER_INCOMING_REQUEST_PRE_HANDLED;
+
+@Interceptor
+public class ReadOnlyInterceptor {
+
+  @Hook(SERVER_INCOMING_REQUEST_PRE_HANDLED)
+  public void incomingRequestPreProcessed(RestOperationTypeEnum theOperation) {
+    if (theOperation != RestOperationTypeEnum.HISTORY_INSTANCE &&
+            theOperation != RestOperationTypeEnum.HISTORY_SYSTEM &&
+            theOperation != RestOperationTypeEnum.HISTORY_TYPE &&
+            theOperation != RestOperationTypeEnum.METADATA &&
+            theOperation != RestOperationTypeEnum.READ &&
+            theOperation != RestOperationTypeEnum.SEARCH_SYSTEM &&
+            theOperation != RestOperationTypeEnum.SEARCH_TYPE &&
+            theOperation != RestOperationTypeEnum.TRANSACTION &&
+            theOperation != RestOperationTypeEnum.VALIDATE &&
+            theOperation != RestOperationTypeEnum.VREAD) {
+      throw new MethodNotAllowedException(theOperation.toString());
+    }
+  }
+}
+
+
+

--- a/src/main/java/org/mitre/fhir/ReadOnlyInterceptor.java
+++ b/src/main/java/org/mitre/fhir/ReadOnlyInterceptor.java
@@ -22,7 +22,8 @@ public class ReadOnlyInterceptor {
             theOperation != RestOperationTypeEnum.TRANSACTION &&
             theOperation != RestOperationTypeEnum.VALIDATE &&
             theOperation != RestOperationTypeEnum.VREAD) {
-      throw new MethodNotAllowedException(theOperation.toString());
+      throw new MethodNotAllowedException("Server is currently `read-only`: the " +
+              theOperation.toString() + " operation is not allowed.");
     }
   }
 }

--- a/src/main/java/org/mitre/fhir/authorization/token/TokenManager.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/TokenManager.java
@@ -36,7 +36,7 @@ public class TokenManager {
 
   /**
    * Gets instance of the TokenManager singleton.
-   * 
+   *
    * @return
    */
   public static TokenManager getInstance() {
@@ -49,7 +49,7 @@ public class TokenManager {
 
   /**
    * Creates a token.
-   * 
+   *
    * @return the created token
    */
   public Token createToken(String scopesString) {
@@ -59,7 +59,7 @@ public class TokenManager {
 
   /**
    * Creates a token.
-   * 
+   *
    * @return the created token
    */
   public Token createToken(List<String> scopes) {
@@ -82,7 +82,7 @@ public class TokenManager {
 
   /**
    * Gets a Token based on the token value.
-   * 
+   *
    * @param tokenValue the token's key value
    * @return the corresponding token
    * @throws TokenNotFoundException if no token with tokenValue exists
@@ -98,7 +98,7 @@ public class TokenManager {
 
   /**
    * Get the corresponding Token for a refresh token.
-   * 
+   *
    * @param refreshTokenValue the refresh token's key value
    * @return the corresponding refresh token
    * @throws TokenNotFoundException if no refresh token with refreshTokenValue exists
@@ -115,9 +115,9 @@ public class TokenManager {
 
   /**
    * Get the refresh token corresponding to a token.
-   * 
+   *
    * @param tokenValue the relevant token value
-   * 
+   *
    * @return refresh token corresponding to the provided token.
    * @throws TokenNotFoundException if the provided token value is not found.
    */
@@ -137,7 +137,7 @@ public class TokenManager {
 
   /**
    * revokes a token.
-   * 
+   *
    * @param tokenValue the token to be revoked.
    * @throws TokenNotFoundException if the provided token value is not found.
    * @throws InactiveTokenException the token has already been revoked.
@@ -162,7 +162,7 @@ public class TokenManager {
 
   /**
    * authenticates if the token is active.
-   * 
+   *
    * @param tokenValue the token to authenticate
    * @return if the token is active
    * @throws TokenNotFoundException if the supplied token is not found.
@@ -176,7 +176,7 @@ public class TokenManager {
 
   /**
    * Authenticates a refresh token.
-   * 
+   *
    * @param refreshTokenValue the refresh token to be authenticated
    * @return boolean indicating whether the refresh token is active
    * @throws TokenNotFoundException if the provided token is not found
@@ -207,7 +207,7 @@ public class TokenManager {
 
   /**
    * Gets a preadded token for calls in the java code.
-   * 
+   *
    * @return a Token
    */
   public Token getServerToken() {

--- a/src/test/java/org/mitre/fhir/TestReadOnlyInterceptor.java
+++ b/src/test/java/org/mitre/fhir/TestReadOnlyInterceptor.java
@@ -1,0 +1,130 @@
+package org.mitre.fhir;
+
+import org.junit.Test;
+import java.io.FileWriter;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Patient;
+import org.mitre.fhir.utils.TestUtils;
+import org.eclipse.jetty.server.Server;
+import ca.uhn.fhir.context.FhirContext;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.mitre.fhir.authorization.token.Token;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import org.mitre.fhir.utils.FhirReferenceServerUtils;
+import org.mitre.fhir.authorization.token.TokenManager;
+import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
+import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
+import ca.uhn.fhir.rest.server.exceptions.MethodNotAllowedException;
+
+public class TestReadOnlyInterceptor {
+
+  private static int ourPort;
+  private static Token testToken;
+  private static Server ourServer;
+  private static FhirContext ourCtx;
+  private static String ourServerBase;
+  private static IGenericClient ourClient;
+  private static String ConfigFileContent;
+
+  @Test(expected = MethodNotAllowedException.class)
+  public void testReadOnlyPreventCreate() throws MethodNotAllowedException {
+    createPatient();
+  }
+
+  @Test(expected = MethodNotAllowedException.class)
+  public void testReadOnlyPreventUpdate() throws MethodNotAllowedException {
+    updatePatient();
+  }
+
+  @Test(expected = MethodNotAllowedException.class)
+  public void testReadOnlyPreventDelete() throws MethodNotAllowedException {
+    deletePatient();
+  }
+
+  private void createPatient() throws MethodNotAllowedException {
+    Patient pt = new Patient();
+    pt.addName().setFamily("Test");
+    ourClient.create().resource(pt)
+            .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+                    FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
+            .execute().getId();
+  }
+
+  private void updatePatient() throws MethodNotAllowedException {
+    Patient pt = new Patient();
+    pt.addName().setFamily("Test");
+    pt.setId("1234");
+    ourClient.update().resource(pt)
+            .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+                    FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
+            .execute().getId();
+  }
+
+  private void deletePatient() throws MethodNotAllowedException {
+    Patient pt = new Patient();
+    pt.addName().setFamily("Test");
+    pt.setId("Patient/1234");
+    ourClient.delete().resource(pt)
+            .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+                    FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
+            .execute().getId();
+  }
+
+  public static String CopyConfig() throws Exception {
+    Path FilePath = Path.of("src/config.properties");
+    return Files.readString(FilePath);
+  }
+
+  public static void OverWriteConfig(String ContentToWrite) throws Exception {
+    FileWriter ConfigWriter = new FileWriter("src/config.properties");
+    ConfigWriter.write("");
+    ConfigWriter.write(ContentToWrite);
+    ConfigWriter.close();
+  }
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+
+    ConfigFileContent = CopyConfig();
+    OverWriteConfig("READ_ONLY=true");
+
+    testToken = TokenManager.getInstance().getServerToken();
+    ourCtx = FhirContext.forR4();
+
+    if (ourPort == 0) { ourPort = TestUtils.TEST_PORT; }
+
+    ourServer = new Server(ourPort);
+
+    String path = Paths.get("").toAbsolutePath().toString();
+
+    WebAppContext webAppContext = new WebAppContext();
+    webAppContext.setContextPath("");
+    webAppContext.setDisplayName("HAPI FHIR");
+    webAppContext.setDescriptor(path + "/src/main/webapp/WEB-INF/web.xml");
+    webAppContext.setResourceBase(path + "/target/mitre-fhir-starter");
+    webAppContext.setParentLoaderPriority(true);
+
+    ourServer.setHandler(webAppContext);
+    ourServer.start();
+
+    ourCtx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
+    ourCtx.getRestfulClientFactory().setSocketTimeout(1200 * 1000);
+    ourServerBase = "http://localhost:" + ourPort + "/reference-server/r4/";
+
+    ourClient = ourCtx.newRestfulGenericClient(ourServerBase);
+    ourClient.registerInterceptor(new LoggingInterceptor(true));
+    ourClient.capabilities();
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    OverWriteConfig(ConfigFileContent);
+    ourServer.stop();
+  }
+}
+

--- a/src/test/java/org/mitre/fhir/TestReadOnlyInterceptor.java
+++ b/src/test/java/org/mitre/fhir/TestReadOnlyInterceptor.java
@@ -1,13 +1,9 @@
 package org.mitre.fhir;
 
 import org.junit.Test;
-import java.io.FileWriter;
-import java.nio.file.Path;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Patient;
 import org.mitre.fhir.utils.TestUtils;
 import org.eclipse.jetty.server.Server;
@@ -75,23 +71,10 @@ public class TestReadOnlyInterceptor {
             .execute().getId();
   }
 
-  public static String CopyConfig() throws Exception {
-    Path FilePath = Path.of("src/config.properties");
-    return Files.readString(FilePath);
-  }
-
-  public static void OverWriteConfig(String ContentToWrite) throws Exception {
-    FileWriter ConfigWriter = new FileWriter("src/config.properties");
-    ConfigWriter.write("");
-    ConfigWriter.write(ContentToWrite);
-    ConfigWriter.close();
-  }
-
   @BeforeClass
   public static void beforeClass() throws Exception {
 
-    ConfigFileContent = CopyConfig();
-    OverWriteConfig("READ_ONLY=true");
+    System.setProperty("READ_ONLY", "true");
 
     testToken = TokenManager.getInstance().getServerToken();
     ourCtx = FhirContext.forR4();
@@ -123,8 +106,7 @@ public class TestReadOnlyInterceptor {
 
   @AfterClass
   public static void afterClass() throws Exception {
-    OverWriteConfig(ConfigFileContent);
+    System.setProperty("READ_ONLY", "false");
     ourServer.stop();
   }
 }
-


### PR DESCRIPTION
# Summary
By default, reference server prevents writes of any kind.

## New behavior
Creating/updating resources is no longer supported. Trying to do so will result in an` OperationOutcome` error with a message that specifies the server is read-only and the attempted operation is not supported.

## Code changes
Created and integrated a ReadOnly receptor into the main server class. The receptor is turned on if `READ_ONLY=true`, either in the environment (Docker) or as a CLI flag (run `mvn jetty:run -DREAD_ONLY=true`). Added unit tests.

## Testing guidance
Run the server locally.  Use Postman (or some other http interface), to attempt to write to the local ref server instance. Additionally, run a local instance of G10 (**note**: run G10 using ruby, not docker, to avoid docker's localhost quirks) with the ref server input pointing to the running local ref server instance. Confirm this reference server updated does not change G10 behavior. 