### PR TITLE
FI-1710: Update Metadata

### DIFF
--- a/src/main/resources/capability-statement-template.json
+++ b/src/main/resources/capability-statement-template.json
@@ -4,6 +4,9 @@
   "date": "2021-06-17T18:03:00+00:00",
   "publisher": "MITRE",
   "kind": "instance",
+  "instantiates": [
+    "http://hl7.org/fhir/us/core/CapabilityStatement/us-core-server"
+  ],
   "implementation": {
     "description": "Inferno Reference Server for US Core Implementation Guide v3.1.1 based on HAPI FHIR R4  Server",
     "url": "$HOST"
@@ -446,7 +449,7 @@
               "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export"
             }
           ]
-        },        
+        },
         {
           "type": "Immunization",
           "supportedProfile": [
@@ -730,7 +733,7 @@
               "type": "string"
             }
           ]
-        	
+
         },
         {
           "type": "Practitioner",
@@ -761,7 +764,7 @@
               "type": "token"
             }
           ],
-          
+
           "operation": [
             {
               "extension": [
@@ -775,7 +778,7 @@
             }
           ]
 
-          
+
         },
         {
           "type": "PractitionerRole",
@@ -869,13 +872,13 @@
             }
           ]
         }
-      ],    
+      ],
       "operation": [
         {
           "name": "get-resource-counts",
           "definition": "$HOST/OperationDefinition/-s-get-resource-counts"
         },
-        { 
+        {
           "extension": [
             {
               "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
@@ -886,7 +889,7 @@
           "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/export"
         }
       ]
-    
+
     }
   ]
 }


### PR DESCRIPTION
# Summary
Update the capability statement served up at the `/metadata` endpoint to meet US Core v4.0.0

## New behavior
Modified capability statement at `/metadata` endpoint.

## Code changes
Add the `"instantiates"` element and value

## Testing guidance
Run the server locally, hit `/metadata` using Postman. Visually confirm change.

![Screen Shot 2022-09-09 at 8 09 00 AM (2)](https://user-images.githubusercontent.com/37051655/189408219-6e00733a-5b69-4fab-bd4f-daaa792336b6.png)