### PR TITLE
FI-1766: Add fields to `.well-known/smart-configuration` and update capabilities field

### DIFF
--- a/src/main/java/org/mitre/fhir/wellknown/WellKnownAuthorizationEndpointController.java
+++ b/src/main/java/org/mitre/fhir/wellknown/WellKnownAuthorizationEndpointController.java
@@ -23,6 +23,7 @@ public class WellKnownAuthorizationEndpointController {
   private static final String WELL_KNOWN_REVOCATION_ENDPOINT_KEY = "revocation_endpoint";
   private static final String WELL_KNOWN_CAPABILITIES_KEY = "capabilities";
   private static final String WELL_KNOWN_JWK_URI_KEY = "jwks_uri";
+  private static final String WELL_KNOWN_GRANT_TYPES_SUPPORTED_KEY = "grant_types_supported";
 
   // 2.1 on
   // http://hl7.org/fhir/smart-app-launch/conformance/index.html#core-capabilities
@@ -43,7 +44,13 @@ public class WellKnownAuthorizationEndpointController {
       "permission-user"
       };
 
+  private static final String[] grantTypesSupportedValues = {
+      "authorization_code",
+      "client_credentials"
+  };
+
   private static final JSONArray WELL_KNOWN_CAPABILITIES_VALUES = new JSONArray(capabilityValues);
+  private static final JSONArray WELL_KNOWN_GRANT_TYPES_SUPPORTED_VALUES = new JSONArray(grantTypesSupportedValues);
 
   @PostConstruct
   protected void postConstruct() {
@@ -68,6 +75,7 @@ public class WellKnownAuthorizationEndpointController {
     wellKnownJson.put(WELL_KNOWN_REVOCATION_ENDPOINT_KEY,
         ServerConformanceWithAuthorizationProvider.getRevokeExtensionUri(theRequest));
     wellKnownJson.put(WELL_KNOWN_CAPABILITIES_KEY, WELL_KNOWN_CAPABILITIES_VALUES);
+    wellKnownJson.put(WELL_KNOWN_GRANT_TYPES_SUPPORTED_KEY, WELL_KNOWN_GRANT_TYPES_SUPPORTED_VALUES);
 
     return wellKnownJson.toString();
   }

--- a/src/main/java/org/mitre/fhir/wellknown/WellKnownAuthorizationEndpointController.java
+++ b/src/main/java/org/mitre/fhir/wellknown/WellKnownAuthorizationEndpointController.java
@@ -43,7 +43,10 @@ public class WellKnownAuthorizationEndpointController {
       "context-standalone-encounter",
       "permission-offline",
       "permission-patient",
-      "permission-user"
+      "permission-user",
+      "permission-v1",
+      "permission-v2",
+      "authorize-post"
       };
 
   private static final String[] grantTypesSupportedValues = {

--- a/src/main/java/org/mitre/fhir/wellknown/WellKnownAuthorizationEndpointController.java
+++ b/src/main/java/org/mitre/fhir/wellknown/WellKnownAuthorizationEndpointController.java
@@ -6,6 +6,8 @@ import java.security.interfaces.RSAPublicKey;
 import java.util.Base64;
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
+
+import org.apache.jena.atlas.json.JSON;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.mitre.fhir.authorization.ServerConformanceWithAuthorizationProvider;
@@ -24,6 +26,7 @@ public class WellKnownAuthorizationEndpointController {
   private static final String WELL_KNOWN_CAPABILITIES_KEY = "capabilities";
   private static final String WELL_KNOWN_JWK_URI_KEY = "jwks_uri";
   private static final String WELL_KNOWN_GRANT_TYPES_SUPPORTED_KEY = "grant_types_supported";
+  private static final String WELL_KNOWN_CODE_CHALLENGE_METHODS_SUPPORTED_KEY = "code_challenge_methods_supported";
 
   // 2.1 on
   // http://hl7.org/fhir/smart-app-launch/conformance/index.html#core-capabilities
@@ -48,10 +51,13 @@ public class WellKnownAuthorizationEndpointController {
       "authorization_code",
       "client_credentials"
   };
+  private static final String[] codeChallengeMethodsSupportedValues = { "S256" };
 
   private static final JSONArray WELL_KNOWN_CAPABILITIES_VALUES = new JSONArray(capabilityValues);
   private static final JSONArray WELL_KNOWN_GRANT_TYPES_SUPPORTED_VALUES =
         new JSONArray(grantTypesSupportedValues);
+  private static final JSONArray WELL_KNOWN_CODE_CHALLENGE_METHODS_SUPPORTED_VALUES =
+        new JSONArray(codeChallengeMethodsSupportedValues);
 
   @PostConstruct
   protected void postConstruct() {
@@ -78,6 +84,8 @@ public class WellKnownAuthorizationEndpointController {
     wellKnownJson.put(WELL_KNOWN_CAPABILITIES_KEY, WELL_KNOWN_CAPABILITIES_VALUES);
     wellKnownJson.put(WELL_KNOWN_GRANT_TYPES_SUPPORTED_KEY,
         WELL_KNOWN_GRANT_TYPES_SUPPORTED_VALUES);
+    wellKnownJson.put(WELL_KNOWN_CODE_CHALLENGE_METHODS_SUPPORTED_KEY,
+        WELL_KNOWN_CODE_CHALLENGE_METHODS_SUPPORTED_VALUES);
 
     return wellKnownJson.toString();
   }

--- a/src/main/java/org/mitre/fhir/wellknown/WellKnownAuthorizationEndpointController.java
+++ b/src/main/java/org/mitre/fhir/wellknown/WellKnownAuthorizationEndpointController.java
@@ -50,7 +50,8 @@ public class WellKnownAuthorizationEndpointController {
   };
 
   private static final JSONArray WELL_KNOWN_CAPABILITIES_VALUES = new JSONArray(capabilityValues);
-  private static final JSONArray WELL_KNOWN_GRANT_TYPES_SUPPORTED_VALUES = new JSONArray(grantTypesSupportedValues);
+  private static final JSONArray WELL_KNOWN_GRANT_TYPES_SUPPORTED_VALUES =
+        new JSONArray(grantTypesSupportedValues);
 
   @PostConstruct
   protected void postConstruct() {
@@ -75,7 +76,8 @@ public class WellKnownAuthorizationEndpointController {
     wellKnownJson.put(WELL_KNOWN_REVOCATION_ENDPOINT_KEY,
         ServerConformanceWithAuthorizationProvider.getRevokeExtensionUri(theRequest));
     wellKnownJson.put(WELL_KNOWN_CAPABILITIES_KEY, WELL_KNOWN_CAPABILITIES_VALUES);
-    wellKnownJson.put(WELL_KNOWN_GRANT_TYPES_SUPPORTED_KEY, WELL_KNOWN_GRANT_TYPES_SUPPORTED_VALUES);
+    wellKnownJson.put(WELL_KNOWN_GRANT_TYPES_SUPPORTED_KEY,
+        WELL_KNOWN_GRANT_TYPES_SUPPORTED_VALUES);
 
     return wellKnownJson.toString();
   }

--- a/src/main/java/org/mitre/fhir/wellknown/WellKnownAuthorizationEndpointController.java
+++ b/src/main/java/org/mitre/fhir/wellknown/WellKnownAuthorizationEndpointController.java
@@ -86,6 +86,8 @@ public class WellKnownAuthorizationEndpointController {
         WELL_KNOWN_GRANT_TYPES_SUPPORTED_VALUES);
     wellKnownJson.put(WELL_KNOWN_CODE_CHALLENGE_METHODS_SUPPORTED_KEY,
         WELL_KNOWN_CODE_CHALLENGE_METHODS_SUPPORTED_VALUES);
+    wellKnownJson.put("issuer", FhirReferenceServerUtils.getFhirServerBaseUrl(theRequest));
+    wellKnownJson.put(WELL_KNOWN_JWK_URI_KEY, FhirReferenceServerUtils.getFhirServerBaseUrl(theRequest) + "/.well-known/jwk");
 
     return wellKnownJson.toString();
   }

--- a/src/main/java/org/mitre/fhir/wellknown/WellKnownAuthorizationEndpointController.java
+++ b/src/main/java/org/mitre/fhir/wellknown/WellKnownAuthorizationEndpointController.java
@@ -6,8 +6,6 @@ import java.security.interfaces.RSAPublicKey;
 import java.util.Base64;
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
-
-import org.apache.jena.atlas.json.JSON;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.mitre.fhir.authorization.ServerConformanceWithAuthorizationProvider;
@@ -26,7 +24,8 @@ public class WellKnownAuthorizationEndpointController {
   private static final String WELL_KNOWN_CAPABILITIES_KEY = "capabilities";
   private static final String WELL_KNOWN_JWK_URI_KEY = "jwks_uri";
   private static final String WELL_KNOWN_GRANT_TYPES_SUPPORTED_KEY = "grant_types_supported";
-  private static final String WELL_KNOWN_CODE_CHALLENGE_METHODS_SUPPORTED_KEY = "code_challenge_methods_supported";
+  private static final String WELL_KNOWN_CODE_CHALLENGE_METHODS_SUPPORTED_KEY =
+        "code_challenge_methods_supported";
 
   // 2.1 on
   // http://hl7.org/fhir/smart-app-launch/conformance/index.html#core-capabilities
@@ -87,7 +86,8 @@ public class WellKnownAuthorizationEndpointController {
     wellKnownJson.put(WELL_KNOWN_CODE_CHALLENGE_METHODS_SUPPORTED_KEY,
         WELL_KNOWN_CODE_CHALLENGE_METHODS_SUPPORTED_VALUES);
     wellKnownJson.put("issuer", FhirReferenceServerUtils.getFhirServerBaseUrl(theRequest));
-    wellKnownJson.put(WELL_KNOWN_JWK_URI_KEY, FhirReferenceServerUtils.getFhirServerBaseUrl(theRequest) + "/.well-known/jwk");
+    wellKnownJson.put(WELL_KNOWN_JWK_URI_KEY,
+        FhirReferenceServerUtils.getFhirServerBaseUrl(theRequest) + "/.well-known/jwk");
 
     return wellKnownJson.toString();
   }


### PR DESCRIPTION
# Summary
Add `grant_types_supported` to `.well-known/smart-configuration`

## New behavior
`.well-known/smart-configuration` now contains new element

## Code changes
Hard-coded the grant types

## Testing guidance
Run the server locally and access the `/.well-known/smart-configuration` endpoint to visually confirm the `grant_types_supported` element. Then, run G10 test kit locally with Ruby, using the SMART STU2 selection, and point it towards your local server instance. Confirm test **1.2.02** passes.

<img width="1523" alt="Screen Shot 2022-09-09 at 10 22 02 AM" src="https://user-images.githubusercontent.com/37051655/189409621-dc0dc567-b771-460d-94d4-8341c0357f87.png">
