### PR TITLE
FI-1729: Post Authorization

### DIFF
--- a/src/main/java/org/mitre/fhir/authorization/AuthorizationViewController.java
+++ b/src/main/java/org/mitre/fhir/authorization/AuthorizationViewController.java
@@ -1,7 +1,13 @@
 package org.mitre.fhir.authorization;
 
+import org.apache.commons.collections4.MultiValuedMap;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
 
 /*
  * Controller that serves the src/main/webapp/WEB-INF/templates/authorization.html template
@@ -9,9 +15,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Controller
 public class AuthorizationViewController {
 
-  @RequestMapping("/authorization")
-  public String showAuthorizationView() {
+  @GetMapping("/authorization")
+  public String showGetAuthorizationView(HttpServletRequest request) {
     return "authorization"; // String will be mapped to corresponding template html file
+  }
+
+  @PostMapping("/authorization")
+  public String showPostAuthorizationView(HttpServletRequest request, @RequestBody MultiValueMap<String, String> payload) {
+    String redirect = UriComponentsBuilder.fromHttpUrl(request.getRequestURL().toString()).queryParams(payload).build().toUriString();
+    return "redirect:" + redirect;
   }
   
   @RequestMapping("/patient-picker")

--- a/src/main/java/org/mitre/fhir/authorization/AuthorizationViewController.java
+++ b/src/main/java/org/mitre/fhir/authorization/AuthorizationViewController.java
@@ -1,13 +1,13 @@
 package org.mitre.fhir.authorization;
 
-import org.apache.commons.collections4.MultiValuedMap;
+import javax.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.Map;
 
 /*
  * Controller that serves the src/main/webapp/WEB-INF/templates/authorization.html template
@@ -20,9 +20,14 @@ public class AuthorizationViewController {
     return "authorization"; // String will be mapped to corresponding template html file
   }
 
+  /**
+   * Redirects POST requests to @GetMapping above.
+   */
   @PostMapping("/authorization")
-  public String showPostAuthorizationView(HttpServletRequest request, @RequestBody MultiValueMap<String, String> payload) {
-    String redirect = UriComponentsBuilder.fromHttpUrl(request.getRequestURL().toString()).queryParams(payload).build().toUriString();
+  public String showPostAuthorizationView(HttpServletRequest request,
+                                          @RequestBody MultiValueMap<String, String> payload) {
+    String redirect = UriComponentsBuilder.fromHttpUrl(request.getRequestURL().toString())
+          .queryParams(payload).build().toUriString();
     return "redirect:" + redirect;
   }
   


### PR DESCRIPTION
# Summary
During the EHR Launch in G10, request for authorization is made using a POST requests. This adds support for handling POST authorization request. 

## New behavior
Directs properly-formed POST authorization requests to the scopes view.

## Code changes
Added a POST Mapping to the authorization endpoint. The mapping uses the request URL and parameters in the body of the request to construct an alternative request url that redirects to the GET Mapping. Flow then continues as it does for typical GET authorization requests.

## Testing guidance
Run the reference server locally and use it as the FHIR endpoint when running the g10 suite locally (I recommend using the command G10_VALIDATOR_URL=http://localhost:4545 INFERNO_HOST=http://localhost:4567 ASYNC_JOBS=false bundle exec puma to avoid docker/localhost quirks). Run the EHR launch group in SMART V2 and follow the normal flow to confirm that POST authorization works.
