### PR TITLE
FI-1672: Remove patient-picker from EHR launch

### DIFF
--- a/src/main/webapp/WEB-INF/templates/app-launch.html
+++ b/src/main/webapp/WEB-INF/templates/app-launch.html
@@ -6,37 +6,50 @@
 
     <title>App Launch</title>
     <meta content="Authorize Cindehr" name="description">
-    
-    <link href="js/lib/bootstrap-4.5.3-dist/css/bootstrap.min.css" rel="stylesheet"> 
+
+    <link href="js/lib/bootstrap-4.5.3-dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="css/site.css" rel="stylesheet">
 </head>
 
 <body>
 
-	<div th:replace="tmpl-banner :: banner"></div>
-	
-	<br>
-	<br>
-	
-    <div id="pageContent" class="container">
-    	<div>
-			<div class="form-row">
-				<div class="col-3 text-right">
-					<label for="appURI">App Launch URI</label>				
-				</div>
-				<div class="form-group col-6">
-					<input id="appURI" type="text" class="form-control"/>
-				</div>
-				<div class="form-group col-3">
-					<button id="launchAppButton" class="btn btn-info">Launch App</button>
-				</div>
-			</div>
-		</div>
-	</div>
+<div th:replace="tmpl-banner :: banner"></div>
 
-    <script src="js/lib/jquery-3.4.1/jquery-3.4.1.min.js"></script>
-	<script src="js/lib/bootstrap-4.5.3-dist/js/bootstrap.min.js"></script>
- 
+<br>
+<br>
+
+<div id="pageContent" class="container">
+    <div>
+        <div class="form-row">
+            <div class="col-3 text-right">
+                <label for="appURI">App Launch URI</label>
+            </div>
+            <div class="form-group col-6">
+                <input id="appURI" type="text" class="form-control"/>
+            </div>
+            <div class="form-group col-3">
+                <button id="launchAppButton" class="btn btn-info">Launch App</button>
+            </div>
+        </div>
+    </div>
+    <div>
+        <div class="form-row">
+            <div class="col-3 text-right">
+                <label for="patientIDSelector">Patient ID</label>
+            </div>
+            <div class="form-group col-6">
+                <select class="form-control" id="patientIDSelector">
+                    <option>85</option>
+                    <option>355</option>
+                </select>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="js/lib/jquery-3.4.1/jquery-3.4.1.min.js"></script>
+<script src="js/lib/bootstrap-4.5.3-dist/js/bootstrap.min.js"></script>
+
 <script>
     $(document).ready(function () {
 
@@ -45,7 +58,7 @@
             const url = '/reference-server/app/fhir-server-path'
             $.get(url, function (data, status) {
                 let issParam = encodeURIComponent(data);
-                let launchParam = "123"; //for now just static, but should be communicated back to fhir reference server and stored http://www.hl7.org/fhir/smart-app-launch/
+                let launchParam = $('#patientIDSelector').val();
                 let appURI = $('#appURI').val();
                 let launchLinkHref = appURI + '?' + 'launch=' + launchParam + '&' + 'iss=' + issParam;
 

--- a/src/main/webapp/js/authorize.js
+++ b/src/main/webapp/js/authorize.js
@@ -29,15 +29,20 @@ window.mitre.fhirreferenceserver.authorize = {
         {
             let launch = urlParams.get('launch');
 
-            const expectedLaunch = "123";
+            const expectedLaunch = ["85", "355"];
 
             // if launch is provided
-            if (launch !== expectedLaunch)
+            if (!expectedLaunch.includes(launch))
             {
                 let htmlSafeLaunch = $('<div class="font-weight-bold" />').text(launch)[0].outerHTML;
                 const launchError = "<div>The Launch value " + htmlSafeLaunch + " is invalid. If you are attempting to simulate an EHR launch, please enter the appropriate launch URI into the form at " + appLaunchUrlLink + ".</div>"
                 window.mitre.fhirreferenceserver.authorize.showErrorMessage(launchError);
                 return;
+            } else if (!urlParams.has('patient_id')) {
+                let this_uri = window.location;
+                let redirect = this_uri + "&patient_id=" + launch;
+                window.location.href = redirect;
+                urlParams.append('patient_id', launch)
             }
         }
 


### PR DESCRIPTION
# Summary
Removed the patient-picker page from the EHR Launch flow. 

## New behavior
Upon receiving an authorization request from within an EHR launch – as denoted by the url containing the `launch` parameter – the reference server prevents navigation to the patient-picker and allows for immediate scope granting. 

## Code changes
Altered the `authorization.js` file to check the url for the `launch` parameter and to append `patient_id=launch` to the url, if the launch parameter has an expected value. By adding a `patient_id` parameter, the patient-picker is circumvented.

## Testing guidance
Run the reference server locally and use it as the FHIR endpoint when running the g10 suite locally (I recommend using the command `G10_VALIDATOR_URL=http://localhost:4545 INFERNO_HOST=http://localhost:4567 ASYNC_JOBS=false bundle exec puma` to avoid docker/localhost quirks). Run the EHR launch group and follow the normal flow.