### PR TITLE
FI-1758: Address "Invalid Token" Error raised by getAllEncounters

### DIFF
--- a/src/main/java/org/mitre/fhir/app/launch/AppLaunchController.java
+++ b/src/main/java/org/mitre/fhir/app/launch/AppLaunchController.java
@@ -20,9 +20,7 @@ public class AppLaunchController {
   @GetMapping(path = "/fhir-server-path")
   public ResponseEntity<String> getFhirServerPath(HttpServletRequest request) {
     String fhirServerBaseUrl = FhirReferenceServerUtils.getFhirServerBaseUrl(request);
-    ResponseEntity<String> responseEntity = new ResponseEntity<String>(fhirServerBaseUrl,
-        HttpStatus.OK);
-    return responseEntity;
+    return new ResponseEntity<String>(fhirServerBaseUrl, HttpStatus.OK);
   }
 
   /**

--- a/src/main/java/org/mitre/fhir/utils/FhirUtils.java
+++ b/src/main/java/org/mitre/fhir/utils/FhirUtils.java
@@ -11,6 +11,8 @@ import org.mitre.fhir.authorization.token.TokenManager;
 
 public class FhirUtils {
 
+  static Token token = TokenManager.getInstance().getServerToken();
+
   public static List<BundleEntryComponent> getAllPatients(IGenericClient client) {
     return getAllResources(client, "Patient");
   }
@@ -54,7 +56,10 @@ public class FhirUtils {
       resources.addAll(bundle.getEntry());
 
       if (bundle.getLink(Bundle.LINK_NEXT) != null) {
-        bundle = client.loadPage().next(bundle).execute();
+        bundle = client.loadPage().next(bundle)
+         .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+            FhirReferenceServerUtils.createAuthorizationHeaderValue(token.getTokenValue()))
+         .execute();
       } else {
         bundle = null;
       }


### PR DESCRIPTION
# Summary
Any method in the `FhirUtils` class (such as `getAllEncounters`) that receives a Bundle and then extracts every resource in that Bundle into an array will issue follow-up `GET_PAGE` request(s), if the Bundle is big enough to need muliple pages. However, the Bearer Token was not being passed as part of those requests, causing them to be denied and the "Invalid Token" error to be thrown. This was actually not an error unique to `getAllEncounters`, but every `getAll` method in `FhirUtils`. However, it only arose while testing `getAllEncounters` because Encounters are the only resource whose quantity requires multiple pages in the returned Bundle.

## New behavior
No longer throws `Invalid Token` when calling `getAllEncounter`.

## Code changes
Add Bearer Token to subsequent `GET_PAGE` request when accessing pages in Bundle.

## Testing guidance
This isn't easy to test because the `FhirUtils.getAllEncounters` method is not directly used in any part of the API, and creating a unit test would mean populating the server with enough encounters to require multiple pages in the bundle (time consuming and repetitive to write). My approach was to add a basic mapping that just calls the method and then hit it with the server running to make sure no error is raised and the Encounters are collected. If testing using Docker, make sure to change the `READ_ONLY` flag, as the GET_PAGE request will be blocked by the read-only interceptor (there's a separate, incoming PR to address that).