### PR TITLE
FI-1759: Allow GET_PAGE requests in ReadOnly Interceptor

### DIFF
--- a/src/main/java/org/mitre/fhir/ReadOnlyInterceptor.java
+++ b/src/main/java/org/mitre/fhir/ReadOnlyInterceptor.java
@@ -27,7 +27,8 @@ public class ReadOnlyInterceptor {
             && theOperation != RestOperationTypeEnum.VALIDATE
             && theOperation != RestOperationTypeEnum.VREAD
             && theOperation != RestOperationTypeEnum.GET_PAGE
-            && theOperation != RestOperationTypeEnum.EXTENDED_OPERATION_INSTANCE) {
+            && theOperation != RestOperationTypeEnum.EXTENDED_OPERATION_INSTANCE
+            && theOperation != RestOperationTypeEnum.EXTENDED_OPERATION_SERVER) {
       throw new MethodNotAllowedException("Server is currently `read-only`: the "
               + theOperation.toString()
               + " operation is not allowed.");

--- a/src/main/java/org/mitre/fhir/ReadOnlyInterceptor.java
+++ b/src/main/java/org/mitre/fhir/ReadOnlyInterceptor.java
@@ -26,7 +26,8 @@ public class ReadOnlyInterceptor {
             && theOperation != RestOperationTypeEnum.TRANSACTION
             && theOperation != RestOperationTypeEnum.VALIDATE
             && theOperation != RestOperationTypeEnum.VREAD
-            && theOperation != RestOperationTypeEnum.GET_PAGE) {
+            && theOperation != RestOperationTypeEnum.GET_PAGE
+            && theOperation != RestOperationTypeEnum.EXTENDED_OPERATION_INSTANCE) {
       throw new MethodNotAllowedException("Server is currently `read-only`: the "
               + theOperation.toString()
               + " operation is not allowed.");

--- a/src/main/java/org/mitre/fhir/ReadOnlyInterceptor.java
+++ b/src/main/java/org/mitre/fhir/ReadOnlyInterceptor.java
@@ -25,7 +25,8 @@ public class ReadOnlyInterceptor {
             && theOperation != RestOperationTypeEnum.SEARCH_TYPE
             && theOperation != RestOperationTypeEnum.TRANSACTION
             && theOperation != RestOperationTypeEnum.VALIDATE
-            && theOperation != RestOperationTypeEnum.VREAD) {
+            && theOperation != RestOperationTypeEnum.VREAD
+            && theOperation != RestOperationTypeEnum.GET_PAGE) {
       throw new MethodNotAllowedException("Server is currently `read-only`: the "
               + theOperation.toString()
               + " operation is not allowed.");

--- a/src/test/java/org/mitre/fhir/TestReadOnlyInterceptor.java
+++ b/src/test/java/org/mitre/fhir/TestReadOnlyInterceptor.java
@@ -48,7 +48,7 @@ public class TestReadOnlyInterceptor {
     ourClient.create().resource(pt)
             .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
                     FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
-            .execute().getId();
+            .execute();
   }
 
   private void updatePatient() throws MethodNotAllowedException {
@@ -58,7 +58,7 @@ public class TestReadOnlyInterceptor {
     ourClient.update().resource(pt)
             .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
                     FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
-            .execute().getId();
+            .execute();
   }
 
   private void deletePatient() throws MethodNotAllowedException {
@@ -68,7 +68,7 @@ public class TestReadOnlyInterceptor {
     ourClient.delete().resource(pt)
             .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
                     FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
-            .execute().getId();
+            .execute();
   }
 
   @BeforeClass


### PR DESCRIPTION
# Summary
Allow GET_PAGE requests to be accepted when the server is in ReadOnly mode. 

## New behavior
GET_PAGE requests will not be blocked nor return a 'the server is currently read only' response/error, but will be accepted by the server.

## Code changes
Added the GET_PAGE request to the list of acceptable requests within the interceptor.

## Testing guidance
Do a search and attempt to read second page of results.