### PR TITLE
FI-1727: Encounter Context in EHR Launch

### DIFF
--- a/src/main/java/org/mitre/fhir/app/launch/AppLaunchController.java
+++ b/src/main/java/org/mitre/fhir/app/launch/AppLaunchController.java
@@ -57,21 +57,18 @@ public class AppLaunchController {
   }
 
   /**
-   * Provides the possible patient and encounter ids to define the EHR Launch context.
+   * Provides ids of available patients and their related encounters.
    * @param theRequest the incoming HTTP Request
    * @return String mapping of patient ids to their encounters
    */
   @GetMapping(path = "/ehr-launch-context-options", produces = {"application/json"})
   public ResponseEntity<String> getEhrLaunchContextOptions(HttpServletRequest theRequest) {
-    String fhirServerBaseUrl = FhirReferenceServerUtils.getServerBaseUrl(theRequest)
-          + FhirReferenceServerUtils.FHIR_SERVER_PATH;
-    FhirContext fhirContext = FhirContext.forR4();
-    IGenericClient client = fhirContext.newRestfulGenericClient(fhirServerBaseUrl);
+    IGenericClient client = FhirReferenceServerUtils.getClientFromRequest(theRequest);
 
-    HashMap<String, List<String>> patientAndEncounterIds = new HashMap<String, List<String>>();
+    HashMap<String, List<String>> patientAndEncounterIds = new HashMap<>();
 
     for (Bundle.BundleEntryComponent patientEntry : FhirUtils.getAllPatients(client)) {
-      List<String> encounterIds = new ArrayList<String>();
+      List<String> encounterIds = new ArrayList<>();
       String patientId = patientEntry.getResource().getIdElement().getIdPart();
 
       for (Bundle.BundleEntryComponent encounterEntry :
@@ -82,6 +79,6 @@ public class AppLaunchController {
     }
 
     JSONObject ehrLaunchContextOptions = new JSONObject(patientAndEncounterIds);
-    return new ResponseEntity<String>(ehrLaunchContextOptions.toString(), HttpStatus.OK);
+    return new ResponseEntity<>(ehrLaunchContextOptions.toString(), HttpStatus.OK);
   }
 }

--- a/src/main/java/org/mitre/fhir/app/launch/AppLaunchController.java
+++ b/src/main/java/org/mitre/fhir/app/launch/AppLaunchController.java
@@ -1,8 +1,15 @@
 package org.mitre.fhir.app.launch;
 
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
+import org.hl7.fhir.r4.model.Bundle;
 import org.json.JSONObject;
 import org.mitre.fhir.utils.FhirReferenceServerUtils;
+import org.mitre.fhir.utils.FhirUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -47,5 +54,34 @@ public class AppLaunchController {
     json.put("font_family_heading",
         "'HelveticaNeue-Light', Helvetica, Arial, 'Lucida Grande', sans-serif;");
     return json.toString();
+  }
+
+  /**
+   * Provides the possible patient and encounter ids to define the EHR Launch context.
+   * @param theRequest the incoming HTTP Request
+   * @return String mapping of patient ids to their encounters
+   */
+  @GetMapping(path = "/ehr-launch-context-options", produces = {"application/json"})
+  public ResponseEntity<String> getEhrLaunchContextOptions(HttpServletRequest theRequest) {
+    String fhirServerBaseUrl = FhirReferenceServerUtils.getServerBaseUrl(theRequest)
+          + FhirReferenceServerUtils.FHIR_SERVER_PATH;
+    FhirContext fhirContext = FhirContext.forR4();
+    IGenericClient client = fhirContext.newRestfulGenericClient(fhirServerBaseUrl);
+
+    HashMap<String, List<String>> patientAndEncounterIds = new HashMap<String, List<String>>();
+
+    for (Bundle.BundleEntryComponent patientEntry : FhirUtils.getAllPatients(client)) {
+      List<String> encounterIds = new ArrayList<String>();
+      String patientId = patientEntry.getResource().getIdElement().getIdPart();
+
+      for (Bundle.BundleEntryComponent encounterEntry :
+            FhirUtils.getAllEncountersWithPatientId(client, patientId)) {
+        encounterIds.add(encounterEntry.getResource().getIdElement().getIdPart());
+      }
+      patientAndEncounterIds.put(patientId, encounterIds);
+    }
+
+    JSONObject ehrLaunchContextOptions = new JSONObject(patientAndEncounterIds);
+    return new ResponseEntity<String>(ehrLaunchContextOptions.toString(), HttpStatus.OK);
   }
 }

--- a/src/main/java/org/mitre/fhir/authorization/token/Token.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/Token.java
@@ -60,12 +60,15 @@ public class Token {
     this.patientId = patientId;
   }
 
-  public void setEncounterId(String encounterId) { this.encounterId = encounterId; }
+  public void setEncounterId(String encounterId) {
+    this.encounterId = encounterId;
+  }
 
   public String getPatientId() {
     return patientId;
   }
 
-  public String getEncounterId() { return encounterId; }
-
+  public String getEncounterId() {
+    return encounterId;
+  }
 }

--- a/src/main/java/org/mitre/fhir/authorization/token/Token.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/Token.java
@@ -8,6 +8,7 @@ public class Token {
   private boolean active = true;
   private final List<String> scopes;
   private String patientId;
+  private String encounterId;
 
   private final String tokenValue;
 
@@ -59,8 +60,12 @@ public class Token {
     this.patientId = patientId;
   }
 
+  public void setEncounterId(String encounterId) { this.encounterId = encounterId; }
+
   public String getPatientId() {
     return patientId;
   }
+
+  public String getEncounterId() { return encounterId; }
 
 }

--- a/src/main/java/org/mitre/fhir/utils/FhirUtils.java
+++ b/src/main/java/org/mitre/fhir/utils/FhirUtils.java
@@ -13,8 +13,6 @@ import org.mitre.fhir.authorization.token.TokenManager;
 
 public class FhirUtils {
 
-  static Token token = TokenManager.getInstance().getServerToken();
-
   public static List<BundleEntryComponent> getAllPatients(IGenericClient client) {
     return getAllResources(client, "Patient");
   }
@@ -56,7 +54,8 @@ public class FhirUtils {
           client.search().forResource(Encounter.class).where(Encounter.PATIENT.hasId(patientId))
             .returnBundle(Bundle.class).cacheControl(new CacheControlDirective().setNoCache(true))
             .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
-                FhirReferenceServerUtils.createAuthorizationHeaderValue(token.getTokenValue()))
+                FhirReferenceServerUtils.createAuthorizationHeaderValue(TokenManager.getInstance()
+                 .getServerToken().getTokenValue()))
             .execute();
 
     return bundleToResourceList(client, bundle);
@@ -76,7 +75,8 @@ public class FhirUtils {
     return client.search().forResource(resourceName).returnBundle(Bundle.class).count(1000)
         .cacheControl(cacheControlDirective)
         .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
-            FhirReferenceServerUtils.createAuthorizationHeaderValue(token.getTokenValue()))
+            FhirReferenceServerUtils.createAuthorizationHeaderValue(TokenManager.getInstance()
+             .getServerToken().getTokenValue()))
         .execute();
   }
 
@@ -90,7 +90,8 @@ public class FhirUtils {
       if (bundle.getLink(Bundle.LINK_NEXT) != null) {
         bundle = client.loadPage().next(bundle)
          .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
-            FhirReferenceServerUtils.createAuthorizationHeaderValue(token.getTokenValue()))
+            FhirReferenceServerUtils.createAuthorizationHeaderValue(TokenManager.getInstance()
+             .getServerToken().getTokenValue()))
          .execute();
       } else {
         bundle = null;

--- a/src/main/webapp/WEB-INF/templates/app-launch.html
+++ b/src/main/webapp/WEB-INF/templates/app-launch.html
@@ -19,10 +19,18 @@
 <br>
 
 <div id="pageContent" class="container">
+    <div style="margin-bottom:40px;">
+        This is a very simplistic interface that mimics the basic functionality of an
+        EHR for launching an external SMART App via the EHR Launch flow.  Enter in the
+        launch URL of the app, select a Patient and Encounter to be provided
+        as context during the launch, and click the Launch App button.  The web browser
+        will be redirected to the launch URL of the app, containing the necessary query
+        parameters as described in the SMART App Launch guide.
+    </div>
     <div>
         <div class="form-row">
             <div class="col-3 text-right">
-                <label for="appURI">App Launch URI</label>
+                <label for="appURI">App Launch URL</label>
             </div>
             <div class="form-group col-6">
                 <input id="appURI" type="text" class="form-control"/>
@@ -39,6 +47,7 @@
             </div>
             <div class="form-group col-6">
                 <select class="form-control" id="patientSelector">
+                    <option>Loading...</option>
                 </select>
             </div>
         </div>
@@ -50,6 +59,7 @@
             </div>
             <div class="form-group col-6">
                 <select class="form-control" id="encounterSelector">
+                    <option>Loading...</option>
                 </select>
             </div>
         </div>
@@ -58,7 +68,7 @@
 
 <script src="js/lib/jquery-3.4.1/jquery-3.4.1.min.js"></script>
 <script src="js/lib/bootstrap-4.5.3-dist/js/bootstrap.min.js"></script>
-<script src="js/app-launch.js?s=v3"></script>
+<script src="js/app-launch.js?s=v5"></script>
 
 <script>
     $(document).ready(function () {

--- a/src/main/webapp/WEB-INF/templates/app-launch.html
+++ b/src/main/webapp/WEB-INF/templates/app-launch.html
@@ -35,12 +35,21 @@
     <div>
         <div class="form-row">
             <div class="col-3 text-right">
-                <label for="patientIDSelector">Patient ID</label>
+                <label for="patientSelector">Patient ID</label>
             </div>
             <div class="form-group col-6">
-                <select class="form-control" id="patientIDSelector">
-                    <option>85</option>
-                    <option>355</option>
+                <select class="form-control" id="patientSelector">
+                </select>
+            </div>
+        </div>
+    </div>
+    <div>
+        <div class="form-row">
+            <div class="col-3 text-right">
+                <label for="encounterSelector">Encounter ID</label>
+            </div>
+            <div class="form-group col-6">
+                <select class="form-control" id="encounterSelector">
                 </select>
             </div>
         </div>
@@ -49,29 +58,12 @@
 
 <script src="js/lib/jquery-3.4.1/jquery-3.4.1.min.js"></script>
 <script src="js/lib/bootstrap-4.5.3-dist/js/bootstrap.min.js"></script>
+<script src="js/app-launch.js?s=v3"></script>
 
 <script>
     $(document).ready(function () {
-
-
-        $('#launchAppButton').click(function () {
-            const url = '/reference-server/app/fhir-server-path'
-            $.get(url, function (data, status) {
-                let issParam = encodeURIComponent(data);
-                let launchParam = $('#patientIDSelector').val();
-                let appURI = $('#appURI').val();
-                let launchLinkHref = appURI + '?' + 'launch=' + launchParam + '&' + 'iss=' + issParam;
-
-                window.location.href = launchLinkHref;
-
-            }).fail(function () {
-                alert("Error getting ISS");
-            });
-        });
-
-
+        window.mitre.fhirreferenceserver.appLaunch.init();
     });
-
 </script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/templates/authorization.html
+++ b/src/main/webapp/WEB-INF/templates/authorization.html
@@ -33,7 +33,7 @@
     </div>
     
     <script src="js/lib/jquery-3.4.1/jquery-3.4.1.min.js"></script>
-    <script src="js/authorize.js?s=v4"></script>
+    <script src="js/authorize.js?s=v5"></script>
 	<script src="js/lib/bootstrap-4.5.3-dist/js/bootstrap.min.js"></script>
     
 

--- a/src/main/webapp/WEB-INF/templates/patient-picker.html
+++ b/src/main/webapp/WEB-INF/templates/patient-picker.html
@@ -31,7 +31,7 @@
 <script src="js/lib/jquery-3.4.1/jquery-3.4.1.min.js"></script>
 <script src="js/lib/DataTables-1.10.20/js/jquery.dataTables.min.js"></script>
 <script src="js/lib/DataTables-1.10.20/js/dataTables.bootstrap4.min.js"></script>
-<script src="js/patient-picker.js?s=v3"></script>
+<script src="js/patient-picker.js?s=v5"></script>
 <script src="js/lib/bootstrap-4.5.3-dist/js/bootstrap.min.js"></script>
 
 <script>

--- a/src/main/webapp/js/app-launch.js
+++ b/src/main/webapp/js/app-launch.js
@@ -11,6 +11,8 @@ window.mitre.fhirreferenceserver.appLaunch = {
         $.getJSON(url, function (data, status) {
             let patientIds = Object.keys(data);
             let encounterIds = Object.values(data);
+            $('#patientSelector').empty();
+            $('#encounterSelector').empty();
 
             $.each(patientIds, function(key, value) {
                 $('#patientSelector')

--- a/src/main/webapp/js/app-launch.js
+++ b/src/main/webapp/js/app-launch.js
@@ -1,0 +1,10 @@
+window.mitre = window.mitre || {};
+window.mitre.fhirreferenceserver = window.mitre.fhirreferenceserver || {};
+window.mitre.fhirreferenceserver.appLaunch = {
+    /**
+     * Initializes the page and all html components including actions
+     */
+     init: function () {
+
+     }
+}

--- a/src/main/webapp/js/app-launch.js
+++ b/src/main/webapp/js/app-launch.js
@@ -1,10 +1,56 @@
 window.mitre = window.mitre || {};
 window.mitre.fhirreferenceserver = window.mitre.fhirreferenceserver || {};
 window.mitre.fhirreferenceserver.appLaunch = {
+
     /**
      * Initializes the page and all html components including actions
      */
      init: function () {
 
+        const url = 'ehr-launch-context-options'
+        $.getJSON(url, function (data, status) {
+            let patientIds = Object.keys(data);
+            let encounterIds = Object.values(data);
+
+            $.each(patientIds, function(key, value) {
+                $('#patientSelector')
+                    .append($('<option>', { value : value })
+                    .text(value));
+            });
+
+            $.each(encounterIds[0], function(key, value) {
+                $('#encounterSelector')
+                    .append($('<option>', { value : value })
+                    .text(value));
+            });
+
+            $('#patientSelector').change( function() {
+                var index = $(this).find('option:selected').index();
+                $('#encounterSelector').empty();
+
+                 $.each(encounterIds[index], function(key, value) {
+                     $('#encounterSelector')
+                        .append($('<option>', { value : value })
+                        .text(value));
+                 });
+            });
+
+            $('#launchAppButton').click(function () {
+                const url = '/reference-server/app/fhir-server-path'
+                $.get(url, function (data, status) {
+                    let issParam = encodeURIComponent(data);
+                    let launchParam = $('#patientSelector').val() + "+" + $('#encounterSelector').val();
+                    let appURI = $('#appURI').val();
+                    let launchLinkHref = appURI + '?' + 'launch=' + launchParam + '&' + 'iss=' + issParam;
+
+                    window.location.href = launchLinkHref;
+
+                }).fail(function () {
+                    alert("Error getting ISS");
+                });
+            });
+        }).fail(function () {
+            alert('Unable to retrieve options for EHR Launch Context.');
+        });
      }
 }

--- a/src/main/webapp/js/authorize.js
+++ b/src/main/webapp/js/authorize.js
@@ -17,15 +17,9 @@ window.mitre.fhirreferenceserver.authorize = {
         const appLaunchUrl = window.location.origin + "/reference-server/app/app-launch";
         const appLaunchUrlLink = '<a class="text-white" href="' + appLaunchUrl + '">' + appLaunchUrl + '</a>'
 
-<<<<<<< HEAD
-        let patient_id = "";
-        let encounter_id = "";
+        let patientId = urlParams.get("patient_id") || "";
+        let encounterId = urlParams.get("encounter_id") || "";
 
-=======
-        let patientId = urlParams.has("patient_id") || "";
-        let encounterId = urlParams.has("encounter_id") || "";
-        
->>>>>>> 13bc0f3 (add encounterID to authorization code, if given)
         if (aud !== expectedAud)
         {
             let htmlSafeAud = $('<span class="font-weight-bold" />').text(aud)[0].outerHTML;

--- a/src/main/webapp/js/authorize.js
+++ b/src/main/webapp/js/authorize.js
@@ -59,11 +59,6 @@ window.mitre.fhirreferenceserver.authorize = {
                 const launchError = "<div>The Launch value " + htmlSafeLaunch + " is invalid. If you are attempting to simulate an EHR launch, please enter the appropriate launch URI into the form at " + appLaunchUrlLink + ".</div>"
                 window.mitre.fhirreferenceserver.authorize.showErrorMessage(launchError);
                 return;
-            } else if (!urlParams.has('patient_id')) {
-                let this_uri = window.location;
-                let redirect = this_uri + "&patient_id=" + launch;
-                window.location.href = redirect;
-                urlParams.append('patient_id', launch)
             }
         }
 

--- a/src/main/webapp/js/authorize.js
+++ b/src/main/webapp/js/authorize.js
@@ -17,9 +17,15 @@ window.mitre.fhirreferenceserver.authorize = {
         const appLaunchUrl = window.location.origin + "/reference-server/app/app-launch";
         const appLaunchUrlLink = '<a class="text-white" href="' + appLaunchUrl + '">' + appLaunchUrl + '</a>'
 
+<<<<<<< HEAD
         let patient_id = "";
         let encounter_id = "";
 
+=======
+        let patientId = urlParams.has("patient_id") || "";
+        let encounterId = urlParams.has("encounter_id") || "";
+        
+>>>>>>> 13bc0f3 (add encounterID to authorization code, if given)
         if (aud !== expectedAud)
         {
             let htmlSafeAud = $('<span class="font-weight-bold" />').text(aud)[0].outerHTML;
@@ -37,8 +43,8 @@ window.mitre.fhirreferenceserver.authorize = {
 
             if (launch.includes(" ")) {
                 const launchArray = launch.split(" ");
-                patient_id = launchArray[0];
-                encounter_id = launchArray[1];
+                patientId = launchArray[0];
+                encounterId = launchArray[1];
 
                 const url = '/reference-server/app/ehr-launch-context-options'
                 $.ajax({
@@ -47,13 +53,13 @@ window.mitre.fhirreferenceserver.authorize = {
                     url: url,
                     success: function(data) {
                         expectedPatientLaunch = Object.keys(data);
-                        expectedEncounterLaunch = Object.values(data)[expectedPatientLaunch.indexOf(patient_id) || 0];
+                        expectedEncounterLaunch = Object.values(data)[expectedPatientLaunch.indexOf(patientId) || 0];
                     }
                 });
             }
 
             // if launch is provided
-            if (!expectedPatientLaunch.includes(patient_id) || !expectedEncounterLaunch.includes(encounter_id))
+            if (!expectedPatientLaunch.includes(patientId) || !expectedEncounterLaunch.includes(encounterId))
             {
                 let htmlSafeLaunch = $('<div class="font-weight-bold" />').text(launch)[0].outerHTML;
                 const launchError = "<div>The Launch value " + htmlSafeLaunch + " is invalid. If you are attempting to simulate an EHR launch, please enter the appropriate launch URI into the form at " + appLaunchUrlLink + ".</div>"
@@ -70,7 +76,7 @@ window.mitre.fhirreferenceserver.authorize = {
         let clientId = urlParams.get('client_id') || '';
 
         // check for a patient id, if no one exists redirect to patient picker
-        if (!urlParams.has('patient_id') && patient_id == "")
+        if (!urlParams.has('patient_id') && patientId == "")
         {
 
             let this_uri = window.location;
@@ -125,14 +131,14 @@ window.mitre.fhirreferenceserver.authorize = {
                 selectedScopes += checkbox.value + " ";
             });
 
-            let patientId = urlParams.get('patient_id');
-
             let base64URLEncodedPatientId = btoa(patientId);
 
             // base64 encoding that is escaped so it can be used in a url
             let base64URLEncodedScopes = btoa(selectedScopes);
 
             let code = sampleCode + "." + base64URLEncodedScopes + "." + base64URLEncodedPatientId;
+
+            if (encounterId !== "") { code = code + "." + btoa(encounterId) }
 
             let redirect = urlParams.get('redirect_uri') + '?code=' + code + '&' + 'state=' + state;
 

--- a/src/main/webapp/js/patient-picker.js
+++ b/src/main/webapp/js/patient-picker.js
@@ -6,7 +6,12 @@ window.mitre.fhirreferenceserver.patientPicker = {
      * initializes the page and all html components including actions
      */
     init: function () {
-        let patientsTable = $('#patients').DataTable();
+        let patientsTable = $('#patients').DataTable( {
+            "language": {
+                "emptyTable": "Loading patient list"
+            }
+        }
+        );
 
         //static code that the HAPI interceptor will look for to return token
         let urlParams = new URLSearchParams(window.location.search);

--- a/src/test/java/org/mitre/fhir/app/launch/TestAppLaunchController.java
+++ b/src/test/java/org/mitre/fhir/app/launch/TestAppLaunchController.java
@@ -1,0 +1,131 @@
+package org.mitre.fhir.app.launch;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.jena.atlas.json.JSON;
+import org.apache.jena.atlas.json.JsonObject;
+import org.apache.jena.atlas.json.JsonString;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Reference;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mitre.fhir.authorization.token.Token;
+import org.mitre.fhir.authorization.token.TokenManager;
+import org.mitre.fhir.utils.FhirReferenceServerUtils;
+import org.mitre.fhir.utils.TestUtils;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.nio.file.Paths;
+import java.util.*;
+
+public class TestAppLaunchController {
+
+  private static IGenericClient ourClient;
+  private static int ourPort;
+  private static Server ourServer;
+  private static IIdType testFirstPatientId;
+  private static IIdType testFirstEncounterId;
+  private static Token testToken;
+
+  @Test
+   public void testGetEhrLaunchContextOptions() throws IOException {
+    AppLaunchController appLaunchController = new AppLaunchController();
+    MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
+
+    mockHttpServletRequest.setServerName("localhost:" + ourServer.getURI().getPort());
+    mockHttpServletRequest.setRequestURI("/app/ehr-launch-context-options");
+
+    ResponseEntity<String> response = appLaunchController.getEhrLaunchContextOptions(mockHttpServletRequest);
+
+    String patientId = testFirstPatientId.getIdPart();
+    JsonObject jsonResponseBody = JSON.parse(Objects.requireNonNull(response.getBody()));
+    String returnedEncounterId = jsonResponseBody.get(patientId).getAsArray().get(0).toString();
+    String encounterId = new JsonString(testFirstEncounterId.getIdPart()).toString();
+    assert(Objects.equals(encounterId, returnedEncounterId));
+  }
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    testToken = TokenManager.getInstance().getServerToken();
+    FhirContext ourCtx = FhirContext.forR4();
+
+    if (ourPort == 0) { ourPort = TestUtils.TEST_PORT; };
+    ourServer = new Server(ourPort);
+
+    String path = Paths.get("").toAbsolutePath().toString();
+
+    WebAppContext webAppContext = new WebAppContext();
+    webAppContext.setDisplayName("HAPI FHIR");
+    webAppContext.setDescriptor(path + "/src/main/webapp/WEB-INF/web.xml");
+    webAppContext.setResourceBase(path + "/target/mitre-fhir-starter");
+    webAppContext.setParentLoaderPriority(true);
+
+    ourServer.setHandler(webAppContext);
+    ourServer.start();
+
+    ourCtx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
+    ourCtx.getRestfulClientFactory().setSocketTimeout(1200 * 1000);
+    String ourServerBase = "http://localhost:" + ourPort + "/reference-server/r4/";
+
+    ourClient = ourCtx.newRestfulGenericClient(ourServerBase);
+    ourClient.capabilities();
+
+    Calendar cal = Calendar.getInstance();
+    cal.set(Calendar.YEAR, 1988);
+    cal.set(Calendar.MONTH, Calendar.JANUARY);
+    cal.set(Calendar.DAY_OF_MONTH, 13);
+    Date birthdate = cal.getTime();
+    // ensure that db is not empty (will be deleted @AfterClass)
+    Patient pt1 = new Patient();
+    pt1.setBirthDate(birthdate);
+
+    pt1.addName().setFamily("Test1");
+    testFirstPatientId = ourClient.create().resource(pt1)
+     .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+      FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
+     .execute().getId();
+
+    Encounter firstEncounter = new Encounter();
+    firstEncounter.setSubject(new Reference().setReference("Patient/" + testFirstPatientId.getIdPart()));
+    testFirstEncounterId = ourClient.create().resource(firstEncounter)
+     .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+      FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
+     .execute().getId();
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+
+    // delete test patient and encounter
+    ourClient.delete().resourceById("Encounter", testFirstEncounterId.getIdPart())
+     .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+      FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
+     .execute();
+
+    ourClient.delete().resourceById("Patient", testFirstPatientId.getIdPart())
+     .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+      FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
+     .execute();
+
+    testFirstPatientId = null;
+    testFirstEncounterId = null;
+
+    // clear db just in case there are any erroneous patients or encounters
+    TestUtils.clearDB(ourClient);
+
+    ourServer.stop();
+  }
+}

--- a/src/test/java/org/mitre/fhir/utils/TestFhirReferenceServerUtils.java
+++ b/src/test/java/org/mitre/fhir/utils/TestFhirReferenceServerUtils.java
@@ -11,23 +11,21 @@ import org.springframework.mock.web.MockHttpServletRequest;
 
 public class TestFhirReferenceServerUtils {
 
-  private static final MockHttpServletRequest mockRequest = new MockHttpServletRequest();
-
   @Test
   public void testGetServerBaseUrl() {
-    String baseUrl = FhirReferenceServerUtils.getServerBaseUrl(mockRequest);
-    Assert.assertEquals("http://www.example.org:123/reference-server", baseUrl);
+    String baseUrl = FhirReferenceServerUtils.getServerBaseUrl(getMockRequest());
+    Assert.assertEquals("http://www.example.org/reference-server", baseUrl);
   }
 
   @Test
   public void testGetServerBaseUrlWithHttpDefaultPort() {
-    mockRequest.setServerPort(80);
-    String baseUrl = FhirReferenceServerUtils.getServerBaseUrl(mockRequest);
+    String baseUrl = FhirReferenceServerUtils.getServerBaseUrl(getMockRequest());
     Assert.assertEquals("http://www.example.org/reference-server", baseUrl);
   }
 
   @Test
   public void testGetServerBaseUrlWithHttpsDefaultPort() {
+    MockHttpServletRequest mockRequest = getMockRequest();
     mockRequest.setScheme("https");
     mockRequest.setServerPort(443);
     String baseUrl = FhirReferenceServerUtils.getServerBaseUrl(mockRequest);
@@ -36,6 +34,7 @@ public class TestFhirReferenceServerUtils {
 
   @Test
   public void testGetFhirServerBaseUrl() {
+    MockHttpServletRequest mockRequest = getMockRequest();
     mockRequest.setServerPort(123);
     String baseUrl = FhirReferenceServerUtils.getFhirServerBaseUrl(mockRequest);
     Assert.assertEquals("http://www.example.org:123/reference-server/r4", baseUrl);
@@ -114,6 +113,8 @@ public class TestFhirReferenceServerUtils {
 
   @Test
   public void testGetClientFromRequestReturnsExistingClient() {
+    MockHttpServletRequest mockRequest = getMockRequest();
+
     IGenericClient newClient = FhirReferenceServerUtils.getClientFromRequest(mockRequest);
     Assert.assertEquals(newClient.getServerBase(), "http://www.example.org/reference-server/r4");
 
@@ -123,7 +124,7 @@ public class TestFhirReferenceServerUtils {
 
   @Test
   public void testGetClientFromRequestCreatesNewClient() {
-    IGenericClient client = FhirReferenceServerUtils.getClientFromRequest(mockRequest);
+    IGenericClient client = FhirReferenceServerUtils.getClientFromRequest(getMockRequest());
     Assert.assertEquals(client.getServerBase(), "http://www.example.org/reference-server/r4");
 
     MockHttpServletRequest differentMockRequest = new MockHttpServletRequest();
@@ -135,10 +136,14 @@ public class TestFhirReferenceServerUtils {
     Assert.assertNotEquals(client, differentClient);
   }
 
-  @BeforeClass
-  public static void beforeClass() throws Exception {
+  public static MockHttpServletRequest getMockRequest() {
+    MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+
     mockRequest.setScheme("http");
+    mockRequest.setServerPort(80);
     mockRequest.setServerName("www.example.org");
     mockRequest.setRequestURI("/.well-known/smart-configuration");
+
+    return mockRequest;
   }
 }

--- a/src/test/java/org/mitre/fhir/utils/TestFhirUtils.java
+++ b/src/test/java/org/mitre/fhir/utils/TestFhirUtils.java
@@ -1,0 +1,164 @@
+package org.mitre.fhir.utils;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.*;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mitre.fhir.authorization.token.Token;
+import org.mitre.fhir.authorization.token.TokenManager;
+
+import java.nio.file.Paths;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+
+public class TestFhirUtils {
+
+  private static IGenericClient ourClient;
+  private static int ourPort;
+  private static Server ourServer;
+  private static IIdType testFirstPatientId;
+  private static IIdType testSecondPatientId;
+  private static IIdType testFirstEncounterId;
+  private static IIdType testSecondEncounterId;
+  private static IIdType testThirdEncounterId;
+  private static Token testToken;
+
+  @Test
+  public void testGetAllEncountersWithPatientId() {
+    List<Bundle.BundleEntryComponent> bundle = FhirUtils.getAllEncountersWithPatientId(ourClient, testFirstPatientId.getIdPart());
+    assert(bundle.size() == 2);
+    Resource firstEntry = bundle.get(0).getResource();
+    Resource secondEntry = bundle.get(1).getResource();
+    assert(firstEntry.getClass() == Encounter.class && secondEntry.getClass() == Encounter.class);
+    assert(Objects.equals(firstEntry.getId(), testFirstEncounterId.toString()));
+    assert(Objects.equals(secondEntry.getId(), testSecondEncounterId.toString()));
+
+    bundle = FhirUtils.getAllEncountersWithPatientId(ourClient, testSecondPatientId.getIdPart());
+    assert(bundle.size() == 1);
+    firstEntry = bundle.get(0).getResource();
+    assert(firstEntry.getClass() == Encounter.class);
+    assert(Objects.equals(firstEntry.getId(), testThirdEncounterId.toString()));
+  }
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    testToken = TokenManager.getInstance().getServerToken();
+    FhirContext ourCtx = FhirContext.forR4();
+
+    if (ourPort == 0) { ourPort = TestUtils.TEST_PORT; };
+    ourServer = new Server(ourPort);
+
+    String path = Paths.get("").toAbsolutePath().toString();
+
+    WebAppContext webAppContext = new WebAppContext();
+    webAppContext.setDisplayName("HAPI FHIR");
+    webAppContext.setDescriptor(path + "/src/main/webapp/WEB-INF/web.xml");
+    webAppContext.setResourceBase(path + "/target/mitre-fhir-starter");
+    webAppContext.setParentLoaderPriority(true);
+
+    ourServer.setHandler(webAppContext);
+    ourServer.start();
+
+    ourCtx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
+    ourCtx.getRestfulClientFactory().setSocketTimeout(1200 * 1000);
+    String ourServerBase = "http://localhost:" + ourPort + "/reference-server/r4/";
+
+    ourClient = ourCtx.newRestfulGenericClient(ourServerBase);
+    ourClient.capabilities();
+
+    Calendar cal = Calendar.getInstance();
+    cal.set(Calendar.YEAR, 1988);
+    cal.set(Calendar.MONTH, Calendar.JANUARY);
+    cal.set(Calendar.DAY_OF_MONTH, 13);
+    Date birthdate = cal.getTime();
+    // ensure that db is not empty (will be deleted @AfterClass)
+    Patient pt1 = new Patient();
+    pt1.setBirthDate(birthdate);
+
+    Patient pt2 = new Patient();
+    pt2.setBirthDate(birthdate);
+
+    pt1.addName().setFamily("Test1");
+    testFirstPatientId = ourClient.create().resource(pt1)
+     .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+      FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
+     .execute().getId();
+
+    pt2.addName().setFamily("Test2");
+    testSecondPatientId = ourClient.create().resource(pt2)
+     .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+      FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
+     .execute().getId();
+
+    Encounter firstEncounter = new Encounter();
+    firstEncounter.setSubject(new Reference().setReference("Patient/" + testFirstPatientId.getIdPart()));
+    testFirstEncounterId = ourClient.create().resource(firstEncounter)
+     .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+      FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
+     .execute().getId();
+
+    Encounter secondEncounter = new Encounter();
+    secondEncounter.setSubject(new Reference().setReference("Patient/" + testFirstPatientId.getIdPart()));
+    testSecondEncounterId = ourClient.create().resource(secondEncounter)
+     .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+      FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
+     .execute().getId();
+
+    Encounter thirdEncounter = new Encounter();
+    thirdEncounter.setSubject(new Reference().setReference("Patient/" + testSecondPatientId.getIdPart()));
+    testThirdEncounterId = ourClient.create().resource(thirdEncounter)
+     .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+      FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
+     .execute().getId();
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+
+    // delete test patient and encounter
+
+    ourClient.delete().resourceById("Encounter", testFirstEncounterId.getIdPart())
+     .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+      FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
+     .execute();
+
+    ourClient.delete().resourceById("Encounter", testSecondEncounterId.getIdPart())
+     .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+      FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
+     .execute();
+
+    ourClient.delete().resourceById("Encounter", testThirdEncounterId.getIdPart())
+     .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+      FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
+     .execute();
+
+    ourClient.delete().resourceById("Patient", testFirstPatientId.getIdPart())
+     .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+      FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
+     .execute();
+
+    ourClient.delete().resourceById("Patient", testSecondPatientId.getIdPart())
+     .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
+      FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
+     .execute();
+
+    testFirstPatientId = null;
+    testSecondPatientId = null;
+    testFirstEncounterId = null;
+    testSecondEncounterId = null;
+    testThirdEncounterId = null;
+
+    // clear db just in case there are any erroneous patients or encounters
+    TestUtils.clearDB(ourClient);
+
+    ourServer.stop();
+  }
+}


### PR DESCRIPTION
# Summary
Add support for selecting the encounter from which an EHR launch occurs, and then passing that encounter information throughout the authorization flow.

## New behavior
The Reference Server App Launch page now includes a dropdown containing the encounters associated with each stored patient. Both the selected patient and encounter are passed to app via the launch context parameter. 


<img width="1784" alt="Screen Shot 2022-10-19 at 12 16 03 PM" src="https://user-images.githubusercontent.com/37051655/196747511-540e00ef-4280-4e31-896c-6269ee7b2f47.png">


The patient-picker is then ignored (will include changes from this [PR](https://github.com/inferno-framework/inferno-reference-server/pull/70)). The encounter selected is then added to the token (and the refresh token). In this example, the app launch occurred from within Encounter 301 of Patient 232.

<img width="1784" alt="Screen Shot 2022-10-19 at 12 29 32 PM" src="https://user-images.githubusercontent.com/37051655/196750773-7e7627d6-3890-4d8e-b091-d74c162e0509.png">

## Code changes

- The Patient ID dropdown was hard-coded, but is now dynamic (as is encounter). These dropdowns take a half second to populate, which is not ideal – I have an idea of how to make it less obvious, but wanted to get feedback first.
- Create 'ehr-launch-context-options' – and created/modified related utils – to get the data for populating the Patient ID and Encounter ID dropdowns.
- Added JavaScript on top of the Reference Server App Launch html page and added dropdowns to that page.
- Altered the authorization endpoint JavaScript to try and extract the patient and encounter IDs from the launch parameter, if possible, and adjust the flow accordingly (don't go to `patient-picker` and add the ids to the authorization code)
- `generateBearerToken` takes encounterId as an argument and includes it within the token, if it's provided. Otherwise, it gets the first encounter by searching on the the given patientId.
- Added encounterId to token. 
- Various unit tests.
- General clean-up as suggested by `checkstyle` and IntelliJ (anything not mentioned above was clean-up).

## Testing guidance
Run without docker (make sure to change the DB config first, as specified in the README) and also run G10 locally using `G10_VALIDATOR_URL=http://localhost:4545 INFERNO_HOST=http://localhost:4567 ASYNC_JOBS=false bundle exec puma`. Run SMART v1 and confirm that the selected encounter is added as part of the token in EHR launch, and that the Standalone and Limited Launches are unchanged. 