### PR TITLE
FI-1671: Fix bulk data warnings

### DIFF
--- a/src/main/resources/capability-statement-template.json
+++ b/src/main/resources/capability-statement-template.json
@@ -446,7 +446,7 @@
                   "valueCode": "SHOULD"
                 }
               ],
-              "name": "group-export",
+              "name": "export",
               "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export"
             }
           ]

--- a/src/main/resources/capability-statement-template.json
+++ b/src/main/resources/capability-statement-template.json
@@ -5,7 +5,8 @@
   "publisher": "MITRE",
   "kind": "instance",
   "instantiates": [
-    "http://hl7.org/fhir/us/core/CapabilityStatement/us-core-server"
+    "http://hl7.org/fhir/us/core/CapabilityStatement/us-core-server",
+    "http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data"
   ],
   "implementation": {
     "description": "Inferno Reference Server for US Core Implementation Guide v3.1.1 based on HAPI FHIR R4  Server",


### PR DESCRIPTION
This branch updates the CapabilityStatement to remove warnings from the bulk data tests.

![Screen Shot 2022-12-01 at 1 03 24 PM](https://user-images.githubusercontent.com/15969967/205128232-902354ca-c977-4f3a-8c14-4010e40e3484.png)
