### PR TITLE
FI-1726: PKCE support

### DIFF
--- a/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
+++ b/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
@@ -286,7 +286,7 @@ public class AuthorizationController {
     String[] scopeList = scopes == null ? new String[0] : scopes.split(" ");
 
     Boolean v2_scope_found = false;
-    String v2_scope_pattern = "\\w+\\.c?r?u?d?s?\\b";
+    String v2_scope_pattern = "\\b(patient|user|system|\\*)/[\\w*]\\.c?r?u?d?s?\\b";
     for(String scope : scopeList) {
       if (scope.matches(v2_scope_pattern)) {
         v2_scope_found = true;
@@ -298,7 +298,7 @@ public class AuthorizationController {
       return;
     }
 
-    if (!codeChallengeMethod.equalsIgnoreCase("S256")) {
+    if (codeChallengeMethod!= null && !codeChallengeMethod.equalsIgnoreCase("S256")) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Only S256 PKCE code challenge method is supported");
     }
 
@@ -319,6 +319,7 @@ public class AuthorizationController {
         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid code verifier");
       }
     } catch (NoSuchAlgorithmException exception) {
+      // This should not be reachable
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unable to process code verifier");
     }
 

--- a/src/main/java/org/mitre/fhir/authorization/token/TokenManager.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/TokenManager.java
@@ -8,10 +8,8 @@ import org.mitre.fhir.authorization.exception.InvalidBearerTokenException;
 import org.mitre.fhir.utils.FhirReferenceServerUtils;
 
 public class TokenManager {
-
   private static final String CUSTOM_BEARER_TOKEN_ENV_KEY = "CUSTOM_BEARER_TOKEN";
   private static final String CUSTOM_BEARER_TOKEN_SCOPE_STRING = "system/*";
-
 
   private static TokenManager instance;
 
@@ -31,7 +29,6 @@ public class TokenManager {
       addTokenToTokenMap(customBearerToken);
       createCorrespondingRefreshToken(customBearerToken);
     }
-
   }
 
   /**

--- a/src/main/java/org/mitre/fhir/utils/FhirReferenceServerUtils.java
+++ b/src/main/java/org/mitre/fhir/utils/FhirReferenceServerUtils.java
@@ -77,6 +77,28 @@ public class FhirReferenceServerUtils {
   }
 
   /**
+   * Create a code embed with the actual code, scopes and patient id.
+   *
+   * @param actualCode the code itself for auth purposes
+   * @param scopes the scopes the user selected for this token
+   * @param patientId the selected patientId
+   * @param codeChallengeMethod PKCE
+   * @param codeChallenge PKCE
+   * @return string representation of code containing the input code, scopes, and patientId
+   */
+  public static String createCode(String actualCode, String scopes, String patientId, String codeChallengeMethod, String codeChallenge) {
+    JSONObject code = new JSONObject();
+
+    if (actualCode != null) code.put("code", actualCode);
+    if (scopes != null) code.put("scopes", scopes);
+    if (patientId != null) code.put("patientId", patientId);
+    if (codeChallengeMethod != null) code.put("codeChallengeMethod", codeChallengeMethod );
+    if (codeChallenge != null) code.put("codeChallenge", codeChallenge);
+
+    return Base64.getEncoder().encodeToString(code.toString().getBytes());
+  }
+
+  /**
    * Create the Authorization Header value.
    * 
    * @param accessToken the access token value

--- a/src/main/java/org/mitre/fhir/utils/FhirReferenceServerUtils.java
+++ b/src/main/java/org/mitre/fhir/utils/FhirReferenceServerUtils.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
+import org.json.JSONObject;
 
 public class FhirReferenceServerUtils {
 
@@ -66,10 +67,13 @@ public class FhirReferenceServerUtils {
    * @return string representation of code containing the input code, scopes, and patientId
    */
   public static String createCode(String actualCode, String scopes, String patientId) {
-    String encodedScope = Base64.getEncoder().encodeToString(scopes.getBytes());
-    String encodedPatientId = Base64.getEncoder().encodeToString(patientId.getBytes());
+    JSONObject code = new JSONObject();
 
-    return actualCode + "." + encodedScope + "." + encodedPatientId;
+    if (actualCode != null) code.put("code", actualCode);
+    if (scopes != null) code.put("scopes", scopes);
+    if (patientId != null) code.put("patientId", patientId);
+
+    return Base64.getEncoder().encodeToString(code.toString().getBytes());
   }
 
   /**

--- a/src/main/resources/hapi.properties
+++ b/src/main/resources/hapi.properties
@@ -1,5 +1,5 @@
 datasource.driver=org.postgresql.Driver
-#datasource.url=jdbc:postgresql://localhost/inferno_rs
+# datasource.url=jdbc:postgresql://localhost/postgres
 datasource.url=jdbc:postgresql://db/postgres
 datasource.username=postgres
 datasource.password=

--- a/src/main/webapp/js/authorize.js
+++ b/src/main/webapp/js/authorize.js
@@ -2,142 +2,148 @@ window.mitre = window.mitre || {};
 window.mitre.fhirreferenceserver = window.mitre.fhirreferenceserver || {};
 window.mitre.fhirreferenceserver.authorize = {
 
-    /**
+  /**
 	 * initializes the page and all html components including actions
 	 */
-    init: function () {
+  init: function () {
 
-        // static code that the HAPI interceptor will look for to return token
-        let urlParams = new URLSearchParams(window.location.search);
+    // static code that the HAPI interceptor will look for to return token
+    let urlParams = new URLSearchParams(window.location.search);
 
-        let aud = urlParams.get('aud');
+    let aud = urlParams.get('aud');
 
-        const expectedAud = window.location.origin + "/reference-server/r4";
+    const expectedAud = window.location.origin + "/reference-server/r4";
 
-        const appLaunchUrl = window.location.origin + "/reference-server/app/app-launch";
-        const appLaunchUrlLink = '<a class="text-white" href="' + appLaunchUrl + '">' + appLaunchUrl + '</a>'
+    const appLaunchUrl = window.location.origin + "/reference-server/app/app-launch";
+    const appLaunchUrlLink = '<a class="text-white" href="' + appLaunchUrl + '">' + appLaunchUrl + '</a>';
 
-        let patientId = urlParams.get("patient_id") || "";
-        let encounterId = urlParams.get("encounter_id") || "";
+    let patientId = urlParams.get("patient_id") || "";
+    let encounterId = urlParams.get("encounter_id") || "";
 
-        if (aud !== expectedAud)
-        {
-            let htmlSafeAud = $('<span class="font-weight-bold" />').text(aud)[0].outerHTML;
-            const launchAudError = "<div>The Audience value " + htmlSafeAud + " is invalid. If you are attempting to simulate an EHR launch, please enter the appropriate launch URI into the form at " + appLaunchUrlLink + ".</div>";
-            window.mitre.fhirreferenceserver.authorize.showErrorMessage(launchAudError);
-            return;
-        }
-
-        if (urlParams.has('launch'))
-        {
-            let launch = urlParams.get('launch');
-
-            let expectedPatientLaunch = [];
-            let expectedEncounterLaunch = [];
-
-            if (launch.includes(" ")) {
-                const launchArray = launch.split(" ");
-                patientId = launchArray[0];
-                encounterId = launchArray[1];
-
-                const url = '/reference-server/app/ehr-launch-context-options'
-                $.ajax({
-                    async: false,
-                    dataType: "json",
-                    url: url,
-                    success: function(data) {
-                        expectedPatientLaunch = Object.keys(data);
-                        expectedEncounterLaunch = Object.values(data)[expectedPatientLaunch.indexOf(patientId) || 0];
-                    }
-                });
-            }
-
-            // if launch is provided
-            if (!expectedPatientLaunch.includes(patientId) || !expectedEncounterLaunch.includes(encounterId))
-            {
-                let htmlSafeLaunch = $('<div class="font-weight-bold" />').text(launch)[0].outerHTML;
-                const launchError = "<div>The Launch value " + htmlSafeLaunch + " is invalid. If you are attempting to simulate an EHR launch, please enter the appropriate launch URI into the form at " + appLaunchUrlLink + ".</div>"
-                window.mitre.fhirreferenceserver.authorize.showErrorMessage(launchError);
-                return;
-            }
-        }
-
-        let clientId = urlParams.get('client_id') || '';
-
-        // check for a patient id, if no one exists redirect to patient picker
-        if (!urlParams.has('patient_id') && patientId == "")
-        {
-
-            let this_uri = window.location;
-            let this_url_encoded = encodeURIComponent(this_uri);
-            let redirect = "../oauth/patient-picker?client_id=" + clientId + "&redirect_uri=" + this_url_encoded;
-            window.location.href = redirect;
-            return;
-        }
-
-        $('#banner').show();
-        $('#pageContent').show();
-
-        let state = urlParams.get('state') || '';
-
-        // static code that the HAPI interceptor will look for to return token
-        let sampleCode = "SAMPLE_CODE";
-
-        let scopes = urlParams.get('scope') || '';
-
-        scopes = scopes.trim();
-
-        let scopesList = scopes.split(' ');
-
-        // load scopes
-        let checkBoxesHtml = '';
-
-        for (let i = 0; i < scopesList.length; i++)
-        {
-            let scope = scopesList[i];
-
-        	if (scope === '')
-        	{
-        		continue;
-        	}
-
-        	let scopeId = "scope-" + i;
-            let scopeCheckboxHtml = '<div class="form-check">'
-            scopeCheckboxHtml += '<input class="form-check-input" id="' + scopeId + '" name="scopeCheckbox" type="checkbox" value="' + scope + '" checked>'
-            scopeCheckboxHtml += '<label class="form-check-label" for="' + scopeId + '">' + scope + '</label>'
-            scopeCheckboxHtml += '</div>';
-
-            checkBoxesHtml += scopeCheckboxHtml;
-        }
-
-        $('#scopes').append(checkBoxesHtml);
-
-        $('#submit').click(function(){
-
-            // get checked scopes
-            let selectedScopes = "";
-            $('#scopes [name="scopeCheckbox"]:checked').each(function(index, checkbox) {
-                selectedScopes += checkbox.value + " ";
-            });
-
-            let base64URLEncodedPatientId = btoa(patientId);
-
-            // base64 encoding that is escaped so it can be used in a url
-            let base64URLEncodedScopes = btoa(selectedScopes);
-
-            let code = sampleCode + "." + base64URLEncodedScopes + "." + base64URLEncodedPatientId;
-
-            if (encounterId !== "") { code = code + "." + btoa(encounterId) }
-
-            let redirect = urlParams.get('redirect_uri') + '?code=' + code + '&' + 'state=' + state;
-
-            window.location.href = redirect;
-        });
-    },
-
-    showErrorMessage(errorMessage)
+    if (aud !== expectedAud)
     {
-        $('#banner').show();
-        $('#errorMessage').html(errorMessage).show();
+      let htmlSafeAud = $('<span class="font-weight-bold" />').text(aud)[0].outerHTML;
+      const launchAudError = "<div>The Audience value " + htmlSafeAud + " is invalid. If you are attempting to simulate an EHR launch, please enter the appropriate launch URI into the form at " + appLaunchUrlLink + ".</div>";
+      window.mitre.fhirreferenceserver.authorize.showErrorMessage(launchAudError);
+      return;
     }
-}
+
+    if (urlParams.has('launch'))
+    {
+      let launch = urlParams.get('launch');
+
+      let expectedPatientLaunch = [];
+      let expectedEncounterLaunch = [];
+
+      if (launch.includes(" ")) {
+        const launchArray = launch.split(" ");
+        patientId = launchArray[0];
+        encounterId = launchArray[1];
+
+        const url = '/reference-server/app/ehr-launch-context-options';
+        $.ajax({
+          async: false,
+          dataType: "json",
+          url: url,
+          success: function(data) {
+            expectedPatientLaunch = Object.keys(data);
+            expectedEncounterLaunch = Object.values(data)[expectedPatientLaunch.indexOf(patientId) || 0];
+          }
+        });
+      }
+
+      // if launch is provided
+      if (!expectedPatientLaunch.includes(patientId) || !expectedEncounterLaunch.includes(encounterId))
+      {
+        let htmlSafeLaunch = $('<div class="font-weight-bold" />').text(launch)[0].outerHTML;
+        const launchError = "<div>The Launch value " + htmlSafeLaunch + " is invalid. If you are attempting to simulate an EHR launch, please enter the appropriate launch URI into the form at " + appLaunchUrlLink + ".</div>";
+        window.mitre.fhirreferenceserver.authorize.showErrorMessage(launchError);
+        return;
+      }
+    }
+
+    let clientId = urlParams.get('client_id') || '';
+
+    // check for a patient id, if no one exists redirect to patient picker
+    if (!urlParams.has('patient_id') && patientId == "")
+    {
+
+      let this_uri = window.location;
+      let this_url_encoded = encodeURIComponent(this_uri);
+      let redirect = "../oauth/patient-picker?client_id=" + clientId + "&redirect_uri=" + this_url_encoded;
+      window.location.href = redirect;
+      return;
+    }
+
+    $('#banner').show();
+    $('#pageContent').show();
+
+    let state = urlParams.get('state') || '';
+
+    const codeChallenge = urlParams.get('code_challenge');
+    const codeChallengeMethod = urlParams.get('code_challenge_method') || 'plain';
+
+    // static code that the HAPI interceptor will look for to return token
+    let sampleCode = "SAMPLE_CODE";
+
+    let scopes = urlParams.get('scope') || '';
+
+    scopes = scopes.trim();
+
+    let scopesList = scopes.split(' ');
+
+    // load scopes
+    let checkBoxesHtml = '';
+
+    for (let i = 0; i < scopesList.length; i++)
+    {
+      let scope = scopesList[i];
+
+      if (scope === '')
+      {
+        continue;
+      }
+
+      let scopeId = "scope-" + i;
+      let scopeCheckboxHtml =
+          `<div class="form-check">
+             <input class="form-check-input" id="${scopeId}" name="scopeCheckbox" type="checkbox" value="${scope}" checked>
+             <label class="form-check-label" for="${scopeId}">${scope}</label>
+           </div>`;
+
+      checkBoxesHtml += scopeCheckboxHtml;
+    }
+
+    $('#scopes').append(checkBoxesHtml);
+
+    $('#submit').click(function(){
+
+      // get checked scopes
+      let selectedScopes = "";
+      $('#scopes [name="scopeCheckbox"]:checked').each(function(index, checkbox) {
+        selectedScopes += `${checkbox.value} `;
+      });
+
+      const codeParams = Object.fromEntries(Object.entries({
+        code: sampleCode,
+        scopes: selectedScopes,
+        patientId,
+        encounterId,
+        codeChallenge,
+        codeChallengeMethod
+      }).filter(([_, v]) => v));
+
+      const code = btoa(JSON.stringify(codeParams));
+
+      let redirect = urlParams.get('redirect_uri') + '?code=' + code + '&' + 'state=' + state;
+
+      window.location.href = redirect;
+    });
+  },
+
+  showErrorMessage(errorMessage)
+  {
+    $('#banner').show();
+    $('#errorMessage').html(errorMessage).show();
+  }
+};

--- a/src/test/java/org/mitre/fhir/authorization/TestAuthorization.java
+++ b/src/test/java/org/mitre/fhir/authorization/TestAuthorization.java
@@ -74,7 +74,6 @@ public class TestAuthorization {
 
   @Test
   public void testCreateAndRead() {
-
     String methodName = "testCreateResourceConditional";
 
     Patient pt = new Patient();
@@ -95,7 +94,6 @@ public class TestAuthorization {
         .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
             FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
         .execute();
-
   }
 
   @Test(expected = AuthenticationException.class)
@@ -134,7 +132,6 @@ public class TestAuthorization {
         .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
             FhirReferenceServerUtils.createAuthorizationHeaderValue(token.getTokenValue()))
         .execute();
-
   }
 
   @Test
@@ -156,7 +153,6 @@ public class TestAuthorization {
         .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
             FhirReferenceServerUtils.createAuthorizationHeaderValue(token.getTokenValue()))
         .execute();
-
   }
 
   @Test(expected = AuthenticationException.class)
@@ -176,7 +172,7 @@ public class TestAuthorization {
       request.setRequestURI(serverBaseUrl);
       request.setServerPort(TestUtils.TEST_PORT);
 
-      authorizationController.getToken("INVALID_CODE", null, null, request);
+      authorizationController.getToken("{\"code\":\"INVALID_CODE\"}", null, null, null, request);
       Assert.fail("Did not get expected Unauthorized ResponseStatusException");
     } catch (ResponseStatusException rse) {
       if (!HttpStatus.UNAUTHORIZED.equals(rse.getStatus())) {
@@ -197,7 +193,7 @@ public class TestAuthorization {
       request.setRequestURI(serverBaseUrl);
       request.setServerPort(TestUtils.TEST_PORT);
 
-      authorizationController.getToken(null, null, "SAMPLE_CLIENT_ID", request);
+      authorizationController.getToken(null, null, "SAMPLE_CLIENT_ID", null, request);
       Assert.fail("Did not get expected Unauthorized ResponseStatusException");
     } catch (ResponseStatusException rse) {
       if (!HttpStatus.UNAUTHORIZED.equals(rse.getStatus())) {
@@ -223,7 +219,7 @@ public class TestAuthorization {
         FhirReferenceServerUtils.createCode(SAMPLE_CODE, scopes, testPatientId.getIdPart());
 
     ResponseEntity<String> tokenResponseEntity =
-        authorizationController.getToken(code, "SAMPLE_PUBLIC_CLIENT_ID", null, request);
+      authorizationController.getToken(code, "SAMPLE_PUBLIC_CLIENT_ID", null, null, request);
 
     ObjectMapper mapper = new ObjectMapper();
 
@@ -231,7 +227,6 @@ public class TestAuthorization {
 
     JsonNode jsonNode = mapper.readTree(jsonString);
     Assert.assertNotNull(jsonNode.get("access_token"));
-
   }
 
   @Test
@@ -250,7 +245,7 @@ public class TestAuthorization {
         FhirReferenceServerUtils.createCode(SAMPLE_CODE, scopes, testPatientId.getIdPart());
 
     ResponseEntity<String> tokenResponseEntity =
-        authorizationController.getToken(code, "SAMPLE_PUBLIC_CLIENT_ID", null, request);
+      authorizationController.getToken(code, "SAMPLE_PUBLIC_CLIENT_ID", null, null, request);
 
     ObjectMapper mapper = new ObjectMapper();
 
@@ -258,7 +253,6 @@ public class TestAuthorization {
 
     JsonNode jsonNode = mapper.readTree(jsonString);
     Assert.assertNotNull(jsonNode.get("access_token"));
-
   }
 
   @Test
@@ -274,7 +268,7 @@ public class TestAuthorization {
     String scopes = "";
     ResponseEntity<String> tokenResponseEntity = authorizationController.getToken(
         FhirReferenceServerUtils.createCode(SAMPLE_CODE, scopes, testPatientId.getIdPart()),
-        "SAMPLE_PUBLIC_CLIENT_ID", null, request);
+        "SAMPLE_PUBLIC_CLIENT_ID", null, null, request);
 
     ObjectMapper mapper = new ObjectMapper();
 
@@ -300,7 +294,7 @@ public class TestAuthorization {
 
     ResponseEntity<String> tokenResponseEntity = authorizationController.getToken(
         FhirReferenceServerUtils.createCode(SAMPLE_CODE, scopes, testPatientId.getIdPart()),
-        "SAMPLE_PUBLIC_CLIENT_ID", null, request);
+        "SAMPLE_PUBLIC_CLIENT_ID", null, null, request);
 
     ObjectMapper mapper = new ObjectMapper();
 
@@ -365,7 +359,6 @@ public class TestAuthorization {
         ServerConformanceWithAuthorizationProvider.getRevokeExtensionUri(request));
     Assert.assertEquals(tokenUri,
         ServerConformanceWithAuthorizationProvider.getTokenExtensionUri(request));
-
   }
 
 
@@ -383,7 +376,7 @@ public class TestAuthorization {
     // shouldn't throw an exception
     authorizationController.getToken(
         FhirReferenceServerUtils.createCode(SAMPLE_CODE, scopes, testPatientId.getIdPart()),
-        SAMPLE_PUBLIC_CLIENT_ID, null, request);
+        SAMPLE_PUBLIC_CLIENT_ID, null, null, request);
   }
 
   @Test(expected = InvalidClientIdException.class)
@@ -396,7 +389,7 @@ public class TestAuthorization {
     request.setServerPort(TestUtils.TEST_PORT);
     AuthorizationController authorizationController = new AuthorizationController();
     authorizationController.getToken(FhirReferenceServerUtils.SAMPLE_CODE, "INVALID_CLIENT_ID",
-        null, request);
+                                     null, null, request);
   }
 
   @Test(expected = InvalidClientIdException.class)
@@ -409,7 +402,7 @@ public class TestAuthorization {
     request.setServerPort(TestUtils.TEST_PORT);
 
     AuthorizationController authorizationController = new AuthorizationController();
-    authorizationController.getToken(FhirReferenceServerUtils.SAMPLE_CODE, null, null, request);
+    authorizationController.getToken(FhirReferenceServerUtils.SAMPLE_CODE, null, null, null, request);
   }
 
   @Test
@@ -424,8 +417,12 @@ public class TestAuthorization {
 
     AuthorizationController authorizationController = new AuthorizationController();
     authorizationController.getToken(
-        FhirReferenceServerUtils.createCode(SAMPLE_CODE, "", testPatientId.getIdPart()), null, null,
-        request);
+        FhirReferenceServerUtils.createCode(SAMPLE_CODE, "", testPatientId.getIdPart()),
+        null,
+        null,
+        null,
+        request
+    );
   }
 
   @Test(expected = ResponseStatusException.class)
@@ -439,8 +436,13 @@ public class TestAuthorization {
     request.addHeader("Authorization", TestUtils.getEncodedBasicAuthorizationHeader());
 
     AuthorizationController authorizationController = new AuthorizationController();
-    authorizationController.getToken(FhirReferenceServerUtils.SAMPLE_CODE, null, null, request);
-
+    authorizationController.getToken(
+        FhirReferenceServerUtils.createCode(SAMPLE_CODE, null, null),
+        null,
+        null,
+        null,
+        request
+    );
   }
 
   @Test
@@ -459,7 +461,7 @@ public class TestAuthorization {
         FhirReferenceServerUtils.createCode(SAMPLE_CODE, scopes, testPatientId.getIdPart());
 
     ResponseEntity<String> tokenResponseEntity =
-        authorizationController.getToken(code, "SAMPLE_PUBLIC_CLIENT_ID", null, request);
+      authorizationController.getToken(code, "SAMPLE_PUBLIC_CLIENT_ID", null, null, request);
 
     ObjectMapper mapper = new ObjectMapper();
 
@@ -489,7 +491,7 @@ public class TestAuthorization {
         FhirReferenceServerUtils.createCode(SAMPLE_CODE, scopes, testPatientId.getIdPart());
 
     ResponseEntity<String> tokenResponseEntity =
-        authorizationController.getToken(code, "SAMPLE_PUBLIC_CLIENT_ID", null, request);
+      authorizationController.getToken(code, "SAMPLE_PUBLIC_CLIENT_ID", null, null, request);
 
     ObjectMapper mapper = new ObjectMapper();
 
@@ -517,7 +519,7 @@ public class TestAuthorization {
 
     ResponseEntity<String> tokenResponseEntity = authorizationController.getToken(
         FhirReferenceServerUtils.createCode(SAMPLE_CODE, scopes, testPatientId.getIdPart()),
-        "SAMPLE_PUBLIC_CLIENT_ID", null, request);
+        "SAMPLE_PUBLIC_CLIENT_ID", null, null, request);
 
     ObjectMapper mapper = new ObjectMapper();
 
@@ -545,7 +547,7 @@ public class TestAuthorization {
 
     ResponseEntity<String> tokenResponseEntity = authorizationController.getToken(
         FhirReferenceServerUtils.createCode(SAMPLE_CODE, scopes, testPatientId.getIdPart()),
-        "SAMPLE_PUBLIC_CLIENT_ID", null, request);
+        "SAMPLE_PUBLIC_CLIENT_ID", null, null, request);
 
     ObjectMapper mapper = new ObjectMapper();
 
@@ -573,7 +575,7 @@ public class TestAuthorization {
     String code = FhirReferenceServerUtils.SAMPLE_CODE + encodedScopes;
 
     AuthorizationController authorizationController = new AuthorizationController();
-    authorizationController.getToken(code, null, null, request);
+    authorizationController.getToken(code, null, null, null, request);
   }
 
   @Test
@@ -592,7 +594,7 @@ public class TestAuthorization {
     // no error should be thrown
     authorizationController.getToken(
         FhirReferenceServerUtils.createCode(SAMPLE_CODE, scopes, testPatientId.getIdPart()), null,
-        null, request);
+        null, null, request);
   }
 
   @Test(expected = InvalidClientSecretException.class)
@@ -607,7 +609,7 @@ public class TestAuthorization {
         SAMPLE_CONFIDENTIAL_CLIENT_ID, "Invalid Client Secret"));
 
     AuthorizationController authorizationController = new AuthorizationController();
-    authorizationController.getToken(FhirReferenceServerUtils.SAMPLE_CODE, null, null, request);
+    authorizationController.getToken(FhirReferenceServerUtils.SAMPLE_CODE, null, null, null, request);
   }
 
   @Test
@@ -624,7 +626,7 @@ public class TestAuthorization {
     String scopes = "";
     ResponseEntity<String> tokenResponseEntity = authorizationController.getToken(
         FhirReferenceServerUtils.createCode(SAMPLE_CODE, scopes, testPatientId.getIdPart()), null,
-        null, request);
+        null, null, request);
     String jsonString = tokenResponseEntity.getBody();
     JSONObject jsonObject = new JSONObject(jsonString);
     String idToken = (String) jsonObject.get("id_token");
@@ -654,11 +656,17 @@ public class TestAuthorization {
     Token token = TokenManager.getInstance().getServerToken();
     Token refreshToken =
         TokenManager.getInstance().getCorrespondingRefreshToken(token.getTokenValue());
+    refreshToken.setPatientId("SAMPLE_PATIENT_ID");
 
     String refreshTokenValue = refreshToken.getTokenValue();
 
-    ResponseEntity<String> tokenResponseEntity = authorizationController.getToken(null,
-        "SAMPLE_PUBLIC_CLIENT_ID", refreshTokenValue, request);
+    ResponseEntity<String> tokenResponseEntity = authorizationController.getToken(
+      null,
+      "SAMPLE_PUBLIC_CLIENT_ID",
+      refreshTokenValue,
+      null,
+      request
+    );
 
     ObjectMapper mapper = new ObjectMapper();
 
@@ -666,7 +674,6 @@ public class TestAuthorization {
 
     JsonNode jsonNode = mapper.readTree(jsonString);
     Assert.assertNotNull(jsonNode.get("access_token"));
-
   }
 
   @Test
@@ -685,7 +692,7 @@ public class TestAuthorization {
     String code = FhirReferenceServerUtils.createCode(SAMPLE_CODE, scopes, patientId);
 
     ResponseEntity<String> tokenResponseEntity =
-        authorizationController.getToken(code, "SAMPLE_PUBLIC_CLIENT_ID", null, request);
+      authorizationController.getToken(code, "SAMPLE_PUBLIC_CLIENT_ID", null, null, request);
 
     ObjectMapper mapper = new ObjectMapper();
 
@@ -701,12 +708,10 @@ public class TestAuthorization {
     request2.setServerPort(TestUtils.TEST_PORT);
     request2.addHeader("Authorization", TestUtils.getEncodedBasicAuthorizationHeader());
 
-
-
     // check that the new token has the same scopes and the new refresh token has the same patient
     // id
     ResponseEntity<String> newTokenResponseEntity =
-        authorizationController.getToken(null, "SAMPLE_PUBLIC_CLIENT_ID", refreshToken, request2);
+      authorizationController.getToken(null, "SAMPLE_PUBLIC_CLIENT_ID", refreshToken, null, request2);
     String newJsonString = newTokenResponseEntity.getBody();
     ObjectMapper mapper2 = new ObjectMapper();
     JsonNode newJsonNode = mapper2.readTree(newJsonString);
@@ -717,9 +722,6 @@ public class TestAuthorization {
     String newPatientId = newJsonNode.get("patient").textValue();
 
     Assert.assertEquals(newPatientId, patientId);
-
-
-
   }
 
   @Test(expected = ResponseStatusException.class)
@@ -734,16 +736,7 @@ public class TestAuthorization {
     request.addHeader("Authorization", TestUtils.getEncodedBasicAuthorizationHeader());
 
     ResponseEntity<String> tokenResponseEntity =
-        authorizationController.getToken(null, "SAMPLE_PUBLIC_CLIENT_ID", null, request);
-
-    ObjectMapper mapper = new ObjectMapper();
-
-    String jsonString = tokenResponseEntity.getBody();
-
-    JsonNode jsonNode = mapper.readTree(jsonString);
-    String accessToken = jsonNode.get("access_token").asText();
-
-    Assert.assertEquals("SAMPLE_ACCESS_TOKEN", accessToken);
+      authorizationController.getToken(null, "SAMPLE_PUBLIC_CLIENT_ID", null, null, request);
   }
 
   @Test(expected = ResponseStatusException.class)
@@ -762,16 +755,7 @@ public class TestAuthorization {
         testPatientId.getIdPart());
 
     ResponseEntity<String> tokenResponseEntity =
-        authorizationController.getToken(null, "SAMPLE_PUBLIC_CLIENT_ID", refreshToken, request);
-
-    ObjectMapper mapper = new ObjectMapper();
-
-    String jsonString = tokenResponseEntity.getBody();
-
-    JsonNode jsonNode = mapper.readTree(jsonString);
-    String accessToken = jsonNode.get("access_token").asText();
-
-    Assert.assertEquals("SAMPLE_ACCESS_TOKEN", accessToken);
+      authorizationController.getToken(null, "SAMPLE_PUBLIC_CLIENT_ID", refreshToken, null, request);
   }
 
   @Test
@@ -805,7 +789,6 @@ public class TestAuthorization {
 
   @AfterClass
   public static void afterClass() throws Exception {
-
     // delete test patient and encounter
 
     ourClient.delete().resourceById(testEncounterId)
@@ -829,8 +812,6 @@ public class TestAuthorization {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-
-
     testToken = TokenManager.getInstance().getServerToken();
 
     ourCtx = FhirContext.forR4();
@@ -880,7 +861,5 @@ public class TestAuthorization {
         .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
             FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
         .execute().getId();
-
   }
-
 }

--- a/src/test/java/org/mitre/fhir/authorization/TestAuthorizationWithNoData.java
+++ b/src/test/java/org/mitre/fhir/authorization/TestAuthorizationWithNoData.java
@@ -45,13 +45,8 @@ public class TestAuthorizationWithNoData {
 
   @Test(expected = ResponseStatusException.class)
   public void testGetTokenNoEncounterProvided() throws IOException, BearerTokenException {
-
-
-    // add a patient
     Patient pt = new Patient();
     pt.addName().setFamily("Test");
-
-
 
     String serverBaseUrl = "";
     MockHttpServletRequest request = new MockHttpServletRequest();
@@ -60,15 +55,19 @@ public class TestAuthorizationWithNoData {
     request.setServerPort(1234);
 
     String scope = "launch/patient launch/encounter";
-    String encodedScope = Base64.getEncoder().encodeToString(scope.getBytes());
-    
+
     AuthorizationController authorizationController = new AuthorizationController();
 
-    authorizationController.getToken("SAMPLE_CODE." + encodedScope, "SAMPLE_PUBLIC_CLIENT_ID", null,
-        request);
-    
+    authorizationController.getToken(
+        FhirReferenceServerUtils.createCode("SAMPLE_CODE", scope, null),
+        "SAMPLE_PUBLIC_CLIENT_ID",
+        null,
+        null,
+        request
+    );
+
     Token testToken = TokenManager.getInstance().getServerToken();
-    
+
     IIdType patientId = ourClient.create().resource(pt)
         .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
             FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
@@ -78,14 +77,10 @@ public class TestAuthorizationWithNoData {
         .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
             FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
         .execute();
-
   }
 
   @Test(expected = ResponseStatusException.class)
   public void testGetTokenNoPatientProvided() throws IOException, BearerTokenException {
-
-
-    
     String serverBaseUrl = "";
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.setLocalAddr("localhost");
@@ -93,12 +88,11 @@ public class TestAuthorizationWithNoData {
     request.setServerPort(1234);
 
     String scope = "launch/patient launch/encounter";
-    String encodedScope = Base64.getEncoder().encodeToString(scope.getBytes());
 
     AuthorizationController authorizationController = new AuthorizationController();
-    authorizationController.getToken("SAMPLE_CODE." + encodedScope, "SAMPLE_PUBLIC_CLIENT_ID", null,
+    authorizationController.getToken(FhirReferenceServerUtils.createCode("SAMPLE_CODE", scope, null), "SAMPLE_PUBLIC_CLIENT_ID", null, null,
         request);
-    
+
     Token testToken = TokenManager.getInstance().getServerToken();
 
     Encounter encounter = new Encounter();
@@ -125,10 +119,9 @@ public class TestAuthorizationWithNoData {
     request.setServerPort(1234);
 
     String scope = "launch/patient launch/encounter";
-    String encodedScope = Base64.getEncoder().encodeToString(scope.getBytes());
 
     AuthorizationController authorizationController = new AuthorizationController();
-    authorizationController.getToken("SAMPLE_CODE." + encodedScope, "SAMPLE_PUBLIC_CLIENT_ID", null,
+    authorizationController.getToken(FhirReferenceServerUtils.createCode("SAMPLE_CODE", scope, null), "SAMPLE_PUBLIC_CLIENT_ID", null, null,
         request);
   }
 


### PR DESCRIPTION
This branch adds PKCE support. It refactors the code generation so that instead of being a series base64-encoded strings with period delimiters, the code is now just a base64-encoded json object so that it's easier to add more fields as needed.