### PR TITLE
FI-1771: Update landing page to mention new standards supported

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.mitre.fhir</groupId>
   <artifactId>inferno-reference-server</artifactId>
-  <version>1.1.1</version>
+  <version>1.2.0</version>
   <packaging>war</packaging>
 
   <name>Inferno FHIR Reference Server</name>

--- a/src/main/webapp/WEB-INF/templates/landing.html
+++ b/src/main/webapp/WEB-INF/templates/landing.html
@@ -23,17 +23,19 @@
 			Standardized API certification tests. It is not intended for use in production systems, or as an authoritative
 			reference for interfaces presented to users during SMART App Launch / OAuth authentication flows.</p>
 
-		<p>Support for <a href="http://hl7.org/fhir/smart-app-launch/1.0.0/">SMART App Launch 1.0.0</a>, including:</p>
+		<p>Support for <a href="http://hl7.org/fhir/smart-app-launch">SMART App Launch v1.0.0 & v2.0.0</a>, including:</p>
 		<ul>
 			<li>Public and Confidential Clients</li>
 			<li>Standalone and EHR Launch</li>
 			<li>Token Refresh</li>
 			<li>Token Revocation</li>
+      <li>Proof Key for Code Exchange (PKCE)</li>
+      <li>POST-based authorization</li>
 		</ul>
 
-		<p>Support for <a href="http://hl7.org/fhir/uv/bulkdata/STU1.0.1/">Bulk Data 1.0.1</a></p>
+		<p>Support for <a href="http://hl7.org/fhir/uv/bulkdata">Bulk Data v1.0.1 & v2.0.0</a></p>
 
-		<p>Support for US Core v3.1.1, including:</p>
+		<p>Support for <a href="http://hl7.org/fhir/us/core/">US Core v3.1.1, v4.0.0, and v5.0.1</a> including:</p>
 		<ul>
 			<li>Support for required API interactions</li>
 			<li>Example resources and patients</li>


### PR DESCRIPTION
Updated the landing page:

![Screen Shot 2022-12-08 at 9 50 58 AM](https://user-images.githubusercontent.com/15969967/206477743-3bb92069-757a-4c56-a703-4dfdd6481bfa.png)
