### PR TITLE
FI-1740: Handle deleted bulk requests

### DIFF
--- a/src/main/java/org/mitre/fhir/bulk/AuthorizationBulkDataExportProvider.java
+++ b/src/main/java/org/mitre/fhir/bulk/AuthorizationBulkDataExportProvider.java
@@ -265,8 +265,10 @@ public class AuthorizationBulkDataExportProvider {
       IBaseOperationOutcome oo = OperationOutcomeUtil.newInstance(myFhirContext);
       OperationOutcomeUtil.addIssue(myFhirContext, oo, "error",
                                     "Bulk export job " + jobId + "not found", null, "not-found");
-      myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToWriter(oo,
-                                                                                response.getWriter());
+      myFhirContext
+          .newJsonParser()
+          .setPrettyPrint(true)
+          .encodeResourceToWriter(oo, response.getWriter());
       response.getWriter().close();
 
       return;

--- a/src/main/java/org/mitre/fhir/bulk/AuthorizationBulkDataExportProvider.java
+++ b/src/main/java/org/mitre/fhir/bulk/AuthorizationBulkDataExportProvider.java
@@ -264,7 +264,7 @@ public class AuthorizationBulkDataExportProvider {
 
       IBaseOperationOutcome oo = OperationOutcomeUtil.newInstance(myFhirContext);
       OperationOutcomeUtil.addIssue(myFhirContext, oo, "error",
-                                    "Bulk export job " + jobId + "not found", null, null);
+                                    "Bulk export job " + jobId + "not found", null, "not-found");
       myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToWriter(oo,
                                                                                 response.getWriter());
       response.getWriter().close();

--- a/src/main/java/org/mitre/fhir/bulk/AuthorizationBulkDataExportProvider.java
+++ b/src/main/java/org/mitre/fhir/bulk/AuthorizationBulkDataExportProvider.java
@@ -261,6 +261,12 @@ public class AuthorizationBulkDataExportProvider {
 
     if (cancelledJobs.contains(jobId)) {
       response.setStatus(Constants.STATUS_HTTP_404_NOT_FOUND);
+
+      IBaseOperationOutcome oo = OperationOutcomeUtil.newInstance(myFhirContext);
+      OperationOutcomeUtil.addIssue(myFhirContext, oo, "error",
+                                    "Bulk export job " + jobId + "not found", null, null);
+      myFhirContext.newJsonParser().setPrettyPrint(true).encodeResourceToWriter(oo,
+                                                                                response.getWriter());
       response.getWriter().close();
 
       return;

--- a/src/test/java/org/mitre/fhir/bulk/AuthorizationBulkDataExportProviderTest.java
+++ b/src/test/java/org/mitre/fhir/bulk/AuthorizationBulkDataExportProviderTest.java
@@ -79,7 +79,6 @@ public class AuthorizationBulkDataExportProviderTest {
       else {
         numOfResourcesMap.put(resourceName, 1);
       }
-
     }
 
     int numOfPatient =
@@ -92,8 +91,23 @@ public class AuthorizationBulkDataExportProviderTest {
     Assert.assertEquals(numOfPatient, 1);
     Assert.assertEquals(numOfEncounters, 1);
     Assert.assertEquals(numOfOrganizations, 1);
+  }
 
+  @Test
+  public void testGroupBulkExportCancel() throws IOException, InterruptedException {
+    String urlString = createGroupExport();
 
+    URL url = new URL(urlString);
+    HttpURLConnection cancelConnection = (HttpURLConnection) url.openConnection();
+    cancelConnection.setRequestMethod("DELETE");
+    cancelConnection.setRequestProperty("Authorization", "Bearer " + testToken.getTokenValue());
+    cancelConnection.disconnect();
+
+    Assert.assertEquals(202, cancelConnection.getResponseCode());
+
+    HttpURLConnection statusConnection = getCheckExportPollStatusExists(urlString);
+
+    Assert.assertEquals(404, statusConnection.getResponseCode());
   }
 
   private HttpURLConnection getCheckExportPollStatusExists(String urlString) throws IOException {


### PR DESCRIPTION
This branch:
- Removes caching from bulk data, so all requests won't share the same id
- Makes the server return a 404 for status requests of cancelled jobs

To test:
- Run the g10 bulk data tests
- Get the status url and bearer token from the delete request
- Make a status request using that url and token in postman. You should get a 404