### PR TITLE
FI-1770: Default to read only

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,14 @@ To revoke a token, go to `reference-server/oauth/token/revoke-token`
 
 The tokens are currently saved in memory, so if the reference server is restarted, all existing tokens will be invalid
 
-## Running Read-Only Mode
+## Running Read-Write Mode
 
-By default, the Dockerized server runs in read-only mode – meaning, operations modifying the state of the server 
-are not supported. For example, requests to CREATE, UPDATE, or DELETE a resource will receive a `405 Method Not Allowed` 
-error. To adjust this while running Docker, change the `READ_ONLY` environment variable to `false` in 
-`./docker-compose.yml`. If running without Docker, the default mode is _not_ read-only. To activate read-only, run 
-`mvn jetty:run -DREAD_ONLY=true` when starting the server.
+By default, the Dockerized server runs in read-only mode – meaning, operations
+modifying the state of the server are not supported. For example, requests to
+CREATE, UPDATE, or DELETE a resource will receive a `405 Method Not Allowed`
+error. To adjust this while running Docker, change the `READ_ONLY` environment
+variable to `false` in `./docker-compose.yml`. If running without Docker, , run
+`mvn jetty:run -DREAD_ONLY=false` when starting the server.
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ By default, the Dockerized server runs in read-only mode – meaning, operations
 modifying the state of the server are not supported. For example, requests to
 CREATE, UPDATE, or DELETE a resource will receive a `405 Method Not Allowed`
 error. To adjust this while running Docker, change the `READ_ONLY` environment
-variable to `false` in `./docker-compose.yml`. If running without Docker, , run
+variable to `false` in `./docker-compose.yml`. If running without Docker, run
 `mvn jetty:run -DREAD_ONLY=false` when starting the server.
 
 ## Running Tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     environment:
       - POSTGRES_HOST=db
       - CUSTOM_BEARER_TOKEN=SAMPLE_TOKEN
-      - READ_ONLY=true
     networks:
       - fhirnet
     depends_on:

--- a/src/main/java/org/mitre/fhir/MitreJpaServer.java
+++ b/src/main/java/org/mitre/fhir/MitreJpaServer.java
@@ -125,7 +125,7 @@ public class MitreJpaServer extends RestfulServer {
 
     registerInterceptor(new FakeOauth2AuthorizationInterceptorAdaptor());
 
-    if (Boolean.parseBoolean(readOnly)) {
+    if (readOnly == null || Boolean.parseBoolean(readOnly)) {
       registerInterceptor(new ReadOnlyInterceptor());
     }
 

--- a/src/test/java/org/mitre/fhir/TestReadOnlyInterceptor.java
+++ b/src/test/java/org/mitre/fhir/TestReadOnlyInterceptor.java
@@ -74,8 +74,6 @@ public class TestReadOnlyInterceptor {
   @BeforeClass
   public static void beforeClass() throws Exception {
 
-    System.setProperty("READ_ONLY", "true");
-
     testToken = TokenManager.getInstance().getServerToken();
     ourCtx = FhirContext.forR4();
 
@@ -106,7 +104,6 @@ public class TestReadOnlyInterceptor {
 
   @AfterClass
   public static void afterClass() throws Exception {
-    System.setProperty("READ_ONLY", "false");
     ourServer.stop();
   }
 }

--- a/src/test/java/org/mitre/fhir/app/launch/TestAppLaunchController.java
+++ b/src/test/java/org/mitre/fhir/app/launch/TestAppLaunchController.java
@@ -59,6 +59,8 @@ public class TestAppLaunchController {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
+    System.setProperty("READ_ONLY", "false");
+
     testToken = TokenManager.getInstance().getServerToken();
     FhirContext ourCtx = FhirContext.forR4();
 
@@ -108,7 +110,6 @@ public class TestAppLaunchController {
 
   @AfterClass
   public static void afterClass() throws Exception {
-
     // delete test patient and encounter
     ourClient.delete().resourceById("Encounter", testFirstEncounterId.getIdPart())
      .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
@@ -119,6 +120,8 @@ public class TestAppLaunchController {
      .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
       FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
      .execute();
+
+    System.setProperty("READ_ONLY", "true");
 
     testFirstPatientId = null;
     testFirstEncounterId = null;

--- a/src/test/java/org/mitre/fhir/authorization/TestAuthorization.java
+++ b/src/test/java/org/mitre/fhir/authorization/TestAuthorization.java
@@ -935,6 +935,8 @@ public class TestAuthorization {
     testPatientId = null;
     testEncounterId = null;
 
+    System.setProperty("READ_ONLY", "true");
+
     // clear db just in case there are any erroneous patients or encounters
     TestUtils.clearDB(ourClient);
 
@@ -943,6 +945,8 @@ public class TestAuthorization {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
+    System.setProperty("READ_ONLY", "false");
+
     testToken = TokenManager.getInstance().getServerToken();
 
     ourCtx = FhirContext.forR4();

--- a/src/test/java/org/mitre/fhir/bulk/AuthorizationBulkDataExportProviderTest.java
+++ b/src/test/java/org/mitre/fhir/bulk/AuthorizationBulkDataExportProviderTest.java
@@ -158,7 +158,7 @@ public class AuthorizationBulkDataExportProviderTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-
+    System.setProperty("READ_ONLY", "false");
 
     testToken = TokenManager.getInstance().getServerToken();
 
@@ -232,8 +232,6 @@ public class AuthorizationBulkDataExportProviderTest {
         .execute().getId();
 
     // TransactionSynchronizationManager.
-
-
   }
 
   @AfterClass
@@ -253,17 +251,16 @@ public class AuthorizationBulkDataExportProviderTest {
     .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
         FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
     .execute();
-  
+
     ourClient.delete().resourceById(testPatientId)
         .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
             FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
         .execute();
-    
+
+    System.setProperty("READ_ONLY", "true");
     // clear db just in case there are any erroneous patients or encounters
     TestUtils.clearDB(ourClient);
 
-
     ourServer.stop();
   }
-
 }

--- a/src/test/java/org/mitre/fhir/bulk/TestBulkInterceptor.java
+++ b/src/test/java/org/mitre/fhir/bulk/TestBulkInterceptor.java
@@ -95,7 +95,7 @@ public class TestBulkInterceptor {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-
+    System.setProperty("READ_ONLY", "false");
 
     testToken = TokenManager.getInstance().getServerToken();
 
@@ -166,14 +166,10 @@ public class TestBulkInterceptor {
         .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
             FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
         .execute().getId();
-
-
-
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
-
     // delete test patient and group
     ourClient.delete().resourceById(groupId)
         .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
@@ -191,10 +187,11 @@ public class TestBulkInterceptor {
             FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
         .execute();
 
+    System.setProperty("READ_ONLY", "true");
+
     // clear db just in case there are any erroneous patients or encounters
     TestUtils.clearDB(ourClient);
 
     ourServer.stop();
   }
-
 }

--- a/src/test/java/org/mitre/fhir/utils/TestFhirUtils.java
+++ b/src/test/java/org/mitre/fhir/utils/TestFhirUtils.java
@@ -50,6 +50,8 @@ public class TestFhirUtils {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
+    System.setProperty("READ_ONLY", "false");
+
     testToken = TokenManager.getInstance().getServerToken();
     FhirContext ourCtx = FhirContext.forR4();
 
@@ -122,7 +124,6 @@ public class TestFhirUtils {
 
   @AfterClass
   public static void afterClass() throws Exception {
-
     // delete test patient and encounter
 
     ourClient.delete().resourceById("Encounter", testFirstEncounterId.getIdPart())
@@ -149,6 +150,8 @@ public class TestFhirUtils {
      .withAdditionalHeader(FhirReferenceServerUtils.AUTHORIZATION_HEADER_NAME,
       FhirReferenceServerUtils.createAuthorizationHeaderValue(testToken.getTokenValue()))
      .execute();
+
+    System.setProperty("READ_ONLY", "true");
 
     testFirstPatientId = null;
     testSecondPatientId = null;


### PR DESCRIPTION
# Summary
Server now defaults to read only mode if the `READ_ONLY` environment variable is not set.