### PR TITLE
FI-1962: Update inferno docker image org

### DIFF
--- a/.github/inferno/docker-compose.yml
+++ b/.github/inferno/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   inferno_program:
-    image: onchealthit/inferno-program:latest
+    image: infernocommunity/inferno-program:latest
     volumes:
       - ./config.yml:/var/www/inferno/config.yml
       - ./wait-for-it/wait-for-it.sh:/var/www/inferno/wait-for-it.sh


### PR DESCRIPTION
Update to go along with moving inferno images off of the onchealthit org.