### PR TITLE
Release 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.mitre.fhir</groupId>
   <artifactId>inferno-reference-server</artifactId>
-  <version>1.3.1</version>
+  <version>2.0.0</version>
   <packaging>war</packaging>
 
   <name>Inferno FHIR Reference Server</name>


### PR DESCRIPTION
Contains two breaking changes:
- bulk token endpoint was moved
- server defaults to read-only

Draft release: https://github.com/inferno-framework/inferno-reference-server/releases/tag/untagged-7a23ddd11f7e9f6dedcc