### PR TITLE
FI-2154 Enable dependabot for dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/" # Location of package manifests (ie, pom.xml)
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/maven_ci.yml
+++ b/.github/workflows/maven_ci.yml
@@ -5,10 +5,13 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
+permissions:
+  contents: write
+ 
 jobs:
   build:
 
@@ -26,6 +29,10 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
+    - name: Generate and Submit Maven Dependency Snapshot
+      uses: advanced-security/maven-dependency-submission-action@v3
+      if: github.ref == 'refs/heads/main'
+      # only run this step on on main branch, not PRs
     - name: Build/Test with Maven
       run: mvn --batch-mode --update-snapshots verify
     - name: Checkstyle


### PR DESCRIPTION
# Summary
This PR enables dependency management with dependabot:
1. The `dependabot.yml` file tells dependabot this is a maven-based repo and it should be able to handle simple version bumps. 
References:  
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates  
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates#supported-repositories-and-ecosystems  



2. The new CI workflow step will enable security warnings on the security tab.   Also note the CI was pointing to branch name `master` not `main` so I updated that. All of the current workflows will need that updated but I fear a lot might not work so I'm going to save the other ones for later.

If you look at the security tab for the repo you'll see something like this:
![image](https://github.com/inferno-framework/fhir-validator-wrapper/assets/13512036/1c210705-8a55-4d57-9156-55d68c7f81bb)
For maven there is an action "advanced-security/maven-dependency-submission-action" which will generate and submit this dependency graph:
https://github.com/marketplace/actions/maven-dependency-tree-dependency-submission
Unfortunately unlike the gradle one this is not "official" but it still looks ok

I've set this up on a fork  https://github.com/dehall/inferno-reference-server and it finds a lot of things to update

# Testing Guidance
Not sure there's any other way to test this than to implement it. Consider forking the repo and applying these changes as a test if you want to explore. (Or I can give access to my fork)

