### PR TITLE
FI-2195: Bump dependencies

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -297,7 +297,7 @@
                       value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
         <module name="JavadocMethod">
-            <property name="scope" value="public"/>
+            <property name="accessModifiers" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,10 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <hapi.version>5.4.0</hapi.version>
+    <hapi.version>5.7.9</hapi.version>
     <jetty_version>9.4.35.v20201120</jetty_version>
-    <checkstyle.plugin.version>3.1.1</checkstyle.plugin.version>
-    <checkstyle.version>8.32</checkstyle.version>
+    <checkstyle.plugin.version>3.3.0</checkstyle.plugin.version>
+    <checkstyle.version>10.12.4</checkstyle.version>
     <checkstyle.config>config/checkstyle/checkstyle.xml</checkstyle.config>
     <sevntu.checkstyle.plugin.version>1.37.1</sevntu.checkstyle.plugin.version>
   </properties>
@@ -157,8 +157,16 @@
 		<dependency>
 		  <groupId>org.json</groupId>
 		  <artifactId>json</artifactId>
-		  <version>20190722</version>
+		  <version>20230618</version>
 		</dependency>
+
+    <!-- TODO: remove this.
+      originally a nested dependency of hapi-jpaserver, only used for randomness in testing. -->
+    <dependency>
+      <groupId>net.sf.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+      <version>2.10.9.2</version>
+    </dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.webjars/bootstrap -->
 		<dependency>
@@ -222,6 +230,61 @@
 		</dependency>
 		
   </dependencies>
+
+  <!--
+    dependencyManagement allows us "to directly specify the versions of artifacts
+    to be used when they are encountered in transitive dependencies
+    or in dependencies where no version has been specified".
+    For example, if a direct dependency above brings in a nested dependency
+    with a vulnerability, we can bump the nested dependency here.
+    (Assuming the new version is still compatible, etc)
+    This section should be reviewed every time we bump direct dependencies.
+  -->
+  <dependencyManagement>
+    <dependencies>
+      <!-- nested dependency of fhir-validation / hapi-fhir-jpaserver-base -->
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>1.24.0</version>
+      </dependency>
+
+      <!-- nested dependency of hapi-fhir-sql-migrate / hapi-fhir-jpaserver-base -->
+      <dependency>
+        <groupId>mysql</groupId>
+        <artifactId>mysql-connector-java</artifactId>
+        <version>8.0.33</version>
+      </dependency>
+
+      <!-- dependency of hapi-fhir-base -->
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>1.10.0</version>
+      </dependency>
+
+      <!-- nested dependency of elasticsearch / hapi-fhir-jpaserver-base -->
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>2.2</version>
+      </dependency>
+
+      <!-- nested dependency of springdoc-openapi-ui / hapi-fhir-jpaserver-base -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-autoconfigure</artifactId>
+        <version>2.7.16</version>
+      </dependency>
+
+      <!-- dependency of hapi-fhir-testpage-overlay -->
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-web</artifactId>
+        <version>5.3.30</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <finalName>inferno-fhir-reference-server</finalName>

--- a/src/main/java/org/mitre/fhir/MitreServerConfig.java
+++ b/src/main/java/org/mitre/fhir/MitreServerConfig.java
@@ -25,6 +25,7 @@ import org.mitre.fhir.bulk.AuthorizationBulkDataExportProvider;
 import org.mitre.fhir.bulk.InfernoGroupBulkItemReader;
 import org.springframework.batch.core.configuration.annotation.BatchConfigurer;
 import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -112,8 +113,8 @@ public class MitreServerConfig extends BaseJavaConfigR4 {
    */
   @Override
   @Bean
-  public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
-    LocalContainerEntityManagerFactoryBean manager = super.entityManagerFactory();
+  public LocalContainerEntityManagerFactoryBean entityManagerFactory(ConfigurableListableBeanFactory myConfigurableListableBeanFactory) {
+    LocalContainerEntityManagerFactoryBean manager = super.entityManagerFactory(myConfigurableListableBeanFactory);
     manager.setPersistenceUnitName("HAPI_PU");
     manager.setDataSource(dataSource());
     manager.setJpaProperties(jpaProperties());

--- a/src/main/java/org/mitre/fhir/bulk/AuthorizationBulkDataExportProvider.java
+++ b/src/main/java/org/mitre/fhir/bulk/AuthorizationBulkDataExportProvider.java
@@ -3,7 +3,6 @@ package org.mitre.fhir.bulk;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.jpa.bulk.export.api.BulkDataExportOptions;
 import ca.uhn.fhir.jpa.bulk.export.api.IBulkDataExportSvc;
 import ca.uhn.fhir.jpa.bulk.export.model.BulkExportResponseJson;
 import ca.uhn.fhir.jpa.bulk.export.provider.BulkDataExportProvider;
@@ -12,9 +11,9 @@ import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.Operation;
 import ca.uhn.fhir.rest.annotation.OperationParam;
-import ca.uhn.fhir.rest.api.CacheControlDirective;
 import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.PreferHeader;
+import ca.uhn.fhir.rest.api.server.bulk.BulkDataExportOptions;
 import ca.uhn.fhir.rest.server.RestfulServerUtils;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
@@ -119,7 +118,7 @@ public class AuthorizationBulkDataExportProvider {
     BulkDataExportOptions bulkDataExportOptions =
         buildSystemBulkExportOptions(theOutputFormat, theType, theSince, theTypeFilter);
     IBulkDataExportSvc.JobInfo outcome =
-        myBulkDataExportSvc.submitJob(bulkDataExportOptions, false);
+        myBulkDataExportSvc.submitJob(bulkDataExportOptions, false, theRequestDetails);
     writePollingLocationToResponseHeaders(theRequestDetails, outcome);
 
     // Add correct headers
@@ -178,7 +177,7 @@ public class AuthorizationBulkDataExportProvider {
     }
 
     IBulkDataExportSvc.JobInfo outcome =
-        myBulkDataExportSvc.submitJob(bulkDataExportOptions, false);
+        myBulkDataExportSvc.submitJob(bulkDataExportOptions, false, theRequestDetails);
     writePollingLocationToResponseHeaders(theRequestDetails, outcome);
 
     // Add correct headers
@@ -237,7 +236,7 @@ public class AuthorizationBulkDataExportProvider {
         buildPatientBulkExportOptions(theOutputFormat, theType, theSince, theTypeFilter);
     validateResourceTypesAllContainPatientSearchParams(bulkDataExportOptions.getResourceTypes());
     IBulkDataExportSvc.JobInfo outcome =
-        myBulkDataExportSvc.submitJob(bulkDataExportOptions, false);
+        myBulkDataExportSvc.submitJob(bulkDataExportOptions, false, theRequestDetails);
     writePollingLocationToResponseHeaders(theRequestDetails, outcome);
 
     // Add correct headers


### PR DESCRIPTION
# Summary
This PR bumps as many dependencies as we can to address security alerts, without bumping the HAPI JPA server from 5.x to 6.x (since that upgrade would probably require significant refactoring/rewriting)

The latest HAPI 5.x release is 5.7.9 so that's what we'll use. I attempted to mix & match JPA server 5.7.9 plus other HAPI libraries version 6.8.3 and it initially appeared to work, but trying to run it resulted in NoClassDefFoundError and the like which may or may not be solvable, so I think it makes the most sense to keep all HAPI libraries at the same version.

This PR also bumps a few other libraries and nested dependencies via the `<dependencyManagement>` section of `pom.xml`. Marked as Draft as this currently addresses the "critical" level alertd but I also want to look at "high" level alerts

## New behavior
Should be none. Any observed differences are unintentional and should be reviewed.

## Code changes
Outside of `pom.xml` changes are only to support any API changes in our dependencies.

## Testing guidance
In addition to just testing the various features to make sure nothing broke, you can run `mvn org.owasp:dependency-check-maven:check` to get a report of vulnerabilities in dependencies (since the dependabot alerts only work on main)