### PR TITLE
FI-2203: Add US Core 6 resources to bulk export

### DIFF
--- a/src/main/java/org/mitre/fhir/bulk/AuthorizationBulkDataExportProvider.java
+++ b/src/main/java/org/mitre/fhir/bulk/AuthorizationBulkDataExportProvider.java
@@ -73,7 +73,8 @@ public class AuthorizationBulkDataExportProvider {
     "Device", "DiagnosticReport", "DocumentReference", "Goal", "Immunization",
     "MedicationRequest", "Observation", "Procedure", "Encounter",
     "Organization", "Practitioner", "Provenance", "Location", "Medication",
-    "ServiceRequest", "RelatedPerson"
+    "ServiceRequest", "RelatedPerson", "Coverage", "MedicationDispense",
+    "Specimen"
   };
 
   static {


### PR DESCRIPTION
# Summary
This branch adds new US Core 6 resources to the bulk data export.

## Testing guidance
If you run the g10 bulk data tests on qa with US Core 6, three tests will skip because the resources aren't exported. To see the fix:
- Run the g10 tests locally
- `docker compose build`
- `docker compose up`
- In the g10 tests, select US Core 6. Use the preset, but make the host `http://localhost:8080` when you run the bulk data tests.
- You should see the that the resources are included in the export and the tests pass.
<img width="1075" alt="Screenshot 2023-11-02 at 9 29 15 AM" src="https://github.com/inferno-framework/inferno-reference-server/assets/15969967/3e258346-60e0-4b14-827b-5c517f058c17">
