### PR TITLE
Delete .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "maven"
-    directory: "/" # Location of package manifests (ie, pom.xml)
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
# Summary
Delete the dependabot.yml file to prevent dependabot from constantly adding new PRs.

Per https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
> You enable Dependabot version updates by checking a dependabot.yml configuration file in to your repository's .github directory. Dependabot then raises pull requests to keep the dependencies you configure up-to-date. 

Deleting this file just means we won't get automated PRs, we'll still get security alerts internally

## New behavior

## Code changes

## Testing guidance
