### PR TITLE
FI-23XX Update for US Core 7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     environment:
       - POSTGRES_HOST=db
       - CUSTOM_BEARER_TOKEN=SAMPLE_TOKEN
-      - READ_ONLY=false
     networks:
       - fhirnet
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     environment:
       - POSTGRES_HOST=db
       - CUSTOM_BEARER_TOKEN=SAMPLE_TOKEN
+      - READ_ONLY=false
     networks:
       - fhirnet
     depends_on:

--- a/us-core-resources/d831ec91-c7a3-4a61-9312-7ff0c4a32134.json
+++ b/us-core-resources/d831ec91-c7a3-4a61-9312-7ff0c4a32134.json
@@ -17955,78 +17955,13 @@
       }
     },
     {
-      "fullUrl": "http://localhost:8080/reference-server/r4/Observation/1102",
-      "resource": {
-      "resourceType": "Observation",
-      "id": "1102",
-      "meta": {
-          "versionId": "1",
-          "lastUpdated": "2023-12-18T11:41:44.383+00:00",
-          "source": "#crLQ8RiwLfNZoYO9",
-          "profile": [
-              "http://hl7.org/fhir/us/core/StructureDefinition/us-core-treatment-intervention-preference|7.0.0-ballot"
-          ]
-      },
-      "status": "final",
-      "category": [
-          {
-              "coding": [
-                  {
-                      "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
-                      "code": "treatment-intervention-preference",
-                      "display": "Treatment Intervention preference"
-                  }
-              ],
-              "text": "Treatment Intervention Preference"
-          }
-      ],
-      "code": {
-          "coding": [
-              {
-                  "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
-                  "code": "treatment-intervention-preference",
-                  "display": "Treatment Intervention Preference"
-              }
-          ],
-          "text": "Treatment Intervention Preference"
-      },
-      "subject": {
-          "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
-      },
-      "effectiveDateTime": "2023-08-30",
-      "performer": [
-          {
-              "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
-          }
-      ],
-      "valueString": "If I am having significant pain or suffering, I would like my doctors to consult a Supportive and Palliative Care Team to help treat my physical, emotional and spiritual discomfort, and to support my family."
-      },
-      "valueCodeableConcept": {
-        "coding": [
-            {
-                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
-                "code": "treatment-intervention-preference",
-                "display": "Treatment Intervention Preference"
-            }
-        ],
-        "text": "Treatment Intervention Preference"
-      },
-      "request":{
-        "method" : "POST",
-        "url" : "Observation"
-      }
-    },
-    {
-      "fullUrl": "http://localhost:8080/reference-server/r4/Observation/1152",
+      "fullUrl": "urn:uuid:47576d19-ec6c-4ab9-b8e0-3e8ed99a35be",
       "resource": {
           "resourceType": "Observation",
-          "id": "1152",
+          "id": "47576d19-ec6c-4ab9-b8e0-3e8ed99a35be",
           "meta": {
-              "versionId": "1",
-              "lastUpdated": "2023-12-18T11:56:14.781+00:00",
-              "source": "#54h6bd9JmAEa5dHS",
               "profile": [
-                  "http://hl7.org/fhir/us/core/StructureDefinition/us-core-care-experience-preference|7.0.0-ballot"
+                  "http://hl7.org/fhir/us/core/StructureDefinition/us-core-treatment-intervention-preference|7.0.0-ballot"
               ]
           },
           "status": "final",
@@ -18035,22 +17970,22 @@
                   "coding": [
                       {
                           "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
-                          "code": "care-experience-preference",
-                          "display": "Care experience preference"
+                          "code": "treatment-intervention-preference",
+                          "display": "Treatment Intervention preference"
                       }
                   ],
-                  "text": "Care Experience Preference"
+                  "text": "Treatment Intervention Preference"
               }
           ],
           "code": {
               "coding": [
                   {
-                      "system": "http://loinc.org",
-                      "code": "95541-9",
-                      "display": "Care experience preference"
+                      "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                      "code": "treatment-intervention-preference",
+                      "display": "Treatment Intervention Preference"
                   }
               ],
-              "text": "Care Experience Preference"
+              "text": "Treatment Intervention Preference"
           },
           "subject": {
               "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
@@ -18061,21 +17996,154 @@
                   "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
               }
           ],
-          "valueString": "For critical or end-of-life care, here are some examples of the things that I would like to have near me, music that I’d like to hear, and other details of my care that would help to keep me happy and relaxed: Like Bach, especially the cantatas.  St. Martin in the Fields",
-          "valueCodeableConcept": {
-            "coding": [
-                {
-                    "system": "http://loinc.org",
-                    "code": "95541-9",
-                    "display": "Care experience preference"
-                }
-            ],
-            "text": "Care Experience Preference"
-        }
+          "valueString": "If I am having significant pain or suffering, I would like my doctors to consult a Supportive and Palliative Care Team to help treat my physical, emotional and spiritual discomfort, and to support my family."
       },
-      "request":{
-        "method" : "POST",
-        "url" : "Observation"
+      "request": {
+          "method": "POST",
+          "url": "Observation"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:a8972ead-fee5-4a96-be8a-9f2a77264d9d",
+      "resource": {
+          "resourceType": "Observation",
+          "id": "a8972ead-fee5-4a96-be8a-9f2a77264d9d",
+          "meta": {
+              "profile": [
+                  "http://hl7.org/fhir/us/core/StructureDefinition/us-core-treatment-intervention-preference|7.0.0-ballot"
+              ]
+          },
+          "status": "final",
+          "category": [
+              {
+                  "coding": [
+                      {
+                          "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                          "code": "treatment-intervention-preference",
+                          "display": "Treatment Intervention preference"
+                      }
+                  ],
+                  "text": "Treatment Intervention Preference"
+              }
+          ],
+          "code": {
+              "coding": [
+                  {
+                      "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                      "code": "treatment-intervention-preference",
+                      "display": "Treatment Intervention Preference"
+                  }
+              ],
+              "text": "Treatment Intervention Preference"
+          },
+          "subject": {
+              "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
+          },
+          "effectiveDateTime": "2023-08-30",
+          "performer": [
+              {
+                  "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
+              }
+          ],
+          "valueCodeableConcept": {
+              "coding": [
+                  {
+                      "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                      "code": "treatment-intervention-preference",
+                      "display": "Treatment Intervention Preference"
+                  }
+              ],
+              "text": "Treatment Intervention Preference"
+          }
+      },
+      "request": {
+          "method": "POST",
+          "url": "Observation"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:db06bd66-469d-4556-9883-cd6a8be1f7e9",
+      "resource": {
+          "resourceType" : "Observation",
+          "id" : "db06bd66-469d-4556-9883-cd6a8be1f7e9",
+          "meta" : {
+            "profile" : ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-care-experience-preference|7.0.0-ballot"]
+          },
+          "status" : "final",
+          "category" : [{
+            "coding" : [{
+              "system" : "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+              "code" : "care-experience-preference",
+              "display" : "Care experience preference"
+            }],
+            "text" : "Care Experience Preference"
+          }],
+          "code" : {
+            "coding" : [{
+              "system" : "http://loinc.org",
+              "code" : "95541-9",
+              "display" : "Care experience preference"
+            }],
+            "text" : "Care Experience Preference"
+          },
+          "subject" : {
+            "reference" : "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
+          },
+          "effectiveDateTime" : "2023-08-30",
+          "performer" : [{
+            "reference" : "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
+          }],
+          "valueString" : "For critical or end-of-life care, here are some examples of the things that I would like to have near me, music that I’d like to hear, and other details of my care that would help to keep me happy and relaxed: Like Bach, especially the cantatas.  St. Martin in the Fields"
+        },
+      "request": {
+          "method": "POST",
+          "url": "Observation"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:bef6c601-bc94-4f55-9f87-7f46afcc2943",
+      "resource": {
+          "resourceType" : "Observation",
+          "id" : "bef6c601-bc94-4f55-9f87-7f46afcc2943",
+          "meta" : {
+            "profile" : ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-care-experience-preference|7.0.0-ballot"]
+          },
+          "status" : "final",
+          "category" : [{
+            "coding" : [{
+              "system" : "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+              "code" : "care-experience-preference",
+              "display" : "Care experience preference"
+            }],
+            "text" : "Care Experience Preference"
+          }],
+          "code" : {
+            "coding" : [{
+              "system" : "http://loinc.org",
+              "code" : "95541-9",
+              "display" : "Care experience preference"
+            }],
+            "text" : "Care Experience Preference"
+          },
+          "subject" : {
+            "reference" : "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
+          },
+          "effectiveDateTime" : "2023-08-30",
+          "performer" : [{
+            "reference" : "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
+          }],
+          "valueCodeableConcept" : {
+              "coding" : [{
+                "system" : "http://loinc.org",
+                "code" : "95541-9",
+                "display" : "Care experience preference"
+              }],
+              "text" : "Care Experience Preference"
+            }
+        },
+      "request": {
+          "method": "POST",
+          "url": "Observation"
       }
     },
     {

--- a/us-core-resources/d831ec91-c7a3-4a61-9312-7ff0c4a32134.json
+++ b/us-core-resources/d831ec91-c7a3-4a61-9312-7ff0c4a32134.json
@@ -16588,6 +16588,18 @@
           },
           {
             "reference": "urn:uuid:1bc16d93-9ac8-4dc7-ad90-e649c01f8b19"
+          },
+          {
+            "reference": "urn:uuid:47576d19-ec6c-4ab9-b8e0-3e8ed99a35be"
+          },
+          {
+            "reference": "urn:uuid:a8972ead-fee5-4a96-be8a-9f2a77264d9d"
+          },
+          {
+            "reference": "urn:uuid:db06bd66-469d-4556-9883-cd6a8be1f7e9"
+          },
+          {
+            "reference": "urn:uuid:bef6c601-bc94-4f55-9f87-7f46afcc2943"
           }
         ],
         "recorded": "1977-07-15T01:11:45.131-04:00",
@@ -17967,6 +17979,12 @@
                   "http://hl7.org/fhir/us/core/StructureDefinition/us-core-treatment-intervention-preference|7.0.0-ballot"
               ]
           },
+          "identifier": [
+            {
+              "system": "https://github.com/inferno-framework/us-core-test-kit",
+              "value": "47576d19-ec6c-4ab9-b8e0-3e8ed99a35be"
+            }
+          ],
           "status": "final",
           "category": [
               {
@@ -17994,11 +18012,6 @@
               "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
           },
           "effectiveDateTime": "2023-08-30",
-          "performer": [
-              {
-                  "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
-              }
-          ],
           "valueString": "If I am having significant pain or suffering, I would like my doctors to consult a Supportive and Palliative Care Team to help treat my physical, emotional and spiritual discomfort, and to support my family."
       },
       "request": {
@@ -18016,6 +18029,12 @@
                   "http://hl7.org/fhir/us/core/StructureDefinition/us-core-treatment-intervention-preference|7.0.0-ballot"
               ]
           },
+          "identifier": [
+            {
+              "system": "https://github.com/inferno-framework/us-core-test-kit",
+              "value": "a8972ead-fee5-4a96-be8a-9f2a77264d9d"
+            }
+          ],
           "status": "final",
           "category": [
               {
@@ -18043,11 +18062,6 @@
               "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
           },
           "effectiveDateTime": "2023-08-30",
-          "performer": [
-              {
-                  "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
-              }
-          ],
           "valueCodeableConcept": {
               "coding": [
                   {
@@ -18072,6 +18086,12 @@
           "meta" : {
             "profile" : ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-care-experience-preference|7.0.0-ballot"]
           },
+          "identifier": [
+            {
+              "system": "https://github.com/inferno-framework/us-core-test-kit",
+              "value": "db06bd66-469d-4556-9883-cd6a8be1f7e9"
+            }
+          ],
           "status" : "final",
           "category" : [{
             "coding" : [{
@@ -18093,9 +18113,6 @@
             "reference" : "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
           },
           "effectiveDateTime" : "2023-08-30",
-          "performer" : [{
-            "reference" : "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
-          }],
           "valueString" : "For critical or end-of-life care, here are some examples of the things that I would like to have near me, music that I’d like to hear, and other details of my care that would help to keep me happy and relaxed: Like Bach, especially the cantatas.  St. Martin in the Fields"
         },
       "request": {
@@ -18111,6 +18128,12 @@
           "meta" : {
             "profile" : ["http://hl7.org/fhir/us/core/StructureDefinition/us-core-care-experience-preference|7.0.0-ballot"]
           },
+          "identifier": [
+            {
+              "system": "https://github.com/inferno-framework/us-core-test-kit",
+              "value": "bef6c601-bc94-4f55-9f87-7f46afcc2943"
+            }
+          ],
           "status" : "final",
           "category" : [{
             "coding" : [{
@@ -18132,9 +18155,6 @@
             "reference" : "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
           },
           "effectiveDateTime" : "2023-08-30",
-          "performer" : [{
-            "reference" : "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
-          }],
           "valueCodeableConcept" : {
               "coding" : [{
                 "system" : "http://loinc.org",

--- a/us-core-resources/d831ec91-c7a3-4a61-9312-7ff0c4a32134.json
+++ b/us-core-resources/d831ec91-c7a3-4a61-9312-7ff0c4a32134.json
@@ -17955,6 +17955,130 @@
       }
     },
     {
+      "fullUrl": "http://localhost:8080/reference-server/r4/Observation/1102",
+      "resource": {
+      "resourceType": "Observation",
+      "id": "1102",
+      "meta": {
+          "versionId": "1",
+          "lastUpdated": "2023-12-18T11:41:44.383+00:00",
+          "source": "#crLQ8RiwLfNZoYO9",
+          "profile": [
+              "http://hl7.org/fhir/us/core/StructureDefinition/us-core-treatment-intervention-preference|7.0.0-ballot"
+          ]
+      },
+      "status": "final",
+      "category": [
+          {
+              "coding": [
+                  {
+                      "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                      "code": "treatment-intervention-preference",
+                      "display": "Treatment Intervention preference"
+                  }
+              ],
+              "text": "Treatment Intervention Preference"
+          }
+      ],
+      "code": {
+          "coding": [
+              {
+                  "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                  "code": "treatment-intervention-preference",
+                  "display": "Treatment Intervention Preference"
+              }
+          ],
+          "text": "Treatment Intervention Preference"
+      },
+      "subject": {
+          "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
+      },
+      "effectiveDateTime": "2023-08-30",
+      "performer": [
+          {
+              "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
+          }
+      ],
+      "valueString": "If I am having significant pain or suffering, I would like my doctors to consult a Supportive and Palliative Care Team to help treat my physical, emotional and spiritual discomfort, and to support my family."
+      },
+      "valueCodeableConcept": {
+        "coding": [
+            {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                "code": "treatment-intervention-preference",
+                "display": "Treatment Intervention Preference"
+            }
+        ],
+        "text": "Treatment Intervention Preference"
+      },
+      "request":{
+        "method" : "POST",
+        "url" : "Observation"
+      }
+    },
+    {
+      "fullUrl": "http://localhost:8080/reference-server/r4/Observation/1152",
+      "resource": {
+          "resourceType": "Observation",
+          "id": "1152",
+          "meta": {
+              "versionId": "1",
+              "lastUpdated": "2023-12-18T11:56:14.781+00:00",
+              "source": "#54h6bd9JmAEa5dHS",
+              "profile": [
+                  "http://hl7.org/fhir/us/core/StructureDefinition/us-core-care-experience-preference|7.0.0-ballot"
+              ]
+          },
+          "status": "final",
+          "category": [
+              {
+                  "coding": [
+                      {
+                          "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                          "code": "care-experience-preference",
+                          "display": "Care experience preference"
+                      }
+                  ],
+                  "text": "Care Experience Preference"
+              }
+          ],
+          "code": {
+              "coding": [
+                  {
+                      "system": "http://loinc.org",
+                      "code": "95541-9",
+                      "display": "Care experience preference"
+                  }
+              ],
+              "text": "Care Experience Preference"
+          },
+          "subject": {
+              "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
+          },
+          "effectiveDateTime": "2023-08-30",
+          "performer": [
+              {
+                  "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
+              }
+          ],
+          "valueString": "For critical or end-of-life care, here are some examples of the things that I would like to have near me, music that I’d like to hear, and other details of my care that would help to keep me happy and relaxed: Like Bach, especially the cantatas.  St. Martin in the Fields",
+          "valueCodeableConcept": {
+            "coding": [
+                {
+                    "system": "http://loinc.org",
+                    "code": "95541-9",
+                    "display": "Care experience preference"
+                }
+            ],
+            "text": "Care Experience Preference"
+        }
+      },
+      "request":{
+        "method" : "POST",
+        "url" : "Observation"
+      }
+    },
+    {
       "fullUrl": "urn:uuid:82115a91-04c9-4654-acb5-72f2806e00fc",
       "resource": {
         "resourceType": "Specimen",

--- a/us-core-resources/d831ec91-c7a3-4a61-9312-7ff0c4a32134.json
+++ b/us-core-resources/d831ec91-c7a3-4a61-9312-7ff0c4a32134.json
@@ -17987,7 +17987,16 @@
           "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
         },
         "collection": {
-          "collectedDateTime": "2005-07-05T18:07:12Z"
+          "collectedDateTime": "2005-07-05T18:07:12Z",
+          "bodySite": {
+              "coding": [
+                  {
+                      "system": "http://snomed.info/sct",
+                      "code": "106004",
+                      "display": "Posterior carpal region"
+                  }
+              ]
+          }
         },
         "container": [
           {
@@ -18001,6 +18010,17 @@
               ],
               "text": "Sterile urine specimen container"
             }
+          }
+        ],
+        "condition": [
+          {
+              "coding": [
+                  {
+                      "system": "http://terminology.hl7.org/CodeSystem/v2-0493",
+                      "code": "AUT",
+                      "display": "Autolyzed"
+                  }
+              ]
           }
         ]
       },
@@ -18060,6 +18080,106 @@
       },
       "request":
       {
+        "method": "POST",
+        "url": "MedicationDispense"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:17991da0-97b0-447c-bb49-185eb104a160",
+      "resource": {
+        "resourceType": "MedicationDispense",
+        "id": "17991da0-97b0-447c-bb49-185eb104a160",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationdispense"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://github.com/inferno-framework/us-core-test-kit",
+            "value": "17991da0-97b0-447c-bb49-185eb104a160"
+          }
+        ],
+        "status": "completed",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+              "code": "476872",
+              "display": "Nizatidine 15 MG/ML Oral Solution"
+            }
+          ],
+          "text": "Nizatidine 15 MG/ML Oral Solution"
+        },
+        "subject": {
+          "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
+        },
+        "context": {
+          "reference": "urn:uuid:09775519-5327-3bbf-cb95-66313dde54ee"
+        },
+        "performer": [
+          {
+            "actor": {
+              "reference": "urn:uuid:eb10a604-ac01-3975-ad58-4c34606af456",
+              "display": "Dr. Patricia625 Kilback373"
+            }
+          },
+          {
+            "actor": {
+              "reference": "urn:uuid:5d4b9df1-93ae-3bc9-b680-03249990e558",
+              "display": "HOLYOKE MEDICAL CENTER"
+            }
+          }
+        ],
+        "authorizingPrescription": [
+          {
+            "reference": "urn:uuid:1f50f7e0-ada9-752c-6cb6-9f4022f76c13",
+            "display": "Aspirin 81 MG Oral Tablet"
+          }
+        ],
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+              "code": "FFC",
+              "display": "First Fill - Complete"
+            }
+          ]
+        },
+        "quantity": {
+          "value": 480,
+          "unit": "mL",
+          "system": "http://unitsofmeasure.org",
+          "code": "mL"
+        },
+        "whenHandedOver": "2016-12-08T06:38:52Z",
+        "dosageInstruction": [
+          {
+            "text": "10 mL bid",
+            "timing": {
+              "repeat": {
+                "boundsPeriod": {
+                  "start": "2008-04-05"
+                },
+                "frequency": 2,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            },
+            "doseAndRate": [
+              {
+                "doseQuantity": {
+                  "value": 10,
+                  "unit": "ml",
+                  "system": "http://unitsofmeasure.org",
+                  "code": "mL"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "request": {
         "method": "POST",
         "url": "MedicationDispense"
       }

--- a/us-core-resources/d831ec91-c7a3-4a61-9312-7ff0c4a32134.json
+++ b/us-core-resources/d831ec91-c7a3-4a61-9312-7ff0c4a32134.json
@@ -16584,6 +16584,9 @@
             "reference": "urn:uuid:82115a91-04c9-4654-acb5-72f2806e00fc"
           },
           {
+            "reference": "urn:uuid:17991da0-97b0-447c-bb49-185eb104a160"
+          },
+          {
             "reference": "urn:uuid:1bc16d93-9ac8-4dc7-ad90-e649c01f8b19"
           }
         ],

--- a/us-core-resources/e91975f5-9445-c11f-cabf-c3c6dae161f2.json
+++ b/us-core-resources/e91975f5-9445-c11f-cabf-c3c6dae161f2.json
@@ -18740,6 +18740,10 @@
               "system": "http://loinc.org",
               "code": "85354-9",
               "display": "Blood pressure panel with all children optional"
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "96607-7"
             }
           ],
           "text": "Blood pressure panel with all children optional"
@@ -18760,6 +18764,10 @@
                   "system": "http://loinc.org",
                   "code": "8462-4",
                   "display": "Diastolic Blood Pressure"
+                },
+                {
+                  "system": "http://loinc.org",
+                  "code": "96609-3"
                 }
               ],
               "text": "Diastolic Blood Pressure"
@@ -18778,6 +18786,10 @@
                   "system": "http://loinc.org",
                   "code": "8480-6",
                   "display": "Systolic Blood Pressure"
+                },
+                {
+                  "system": "http://loinc.org",
+                  "code": "96608-5"
                 }
               ],
               "text": "Systolic Blood Pressure"
@@ -32950,6 +32962,10 @@
               "system": "http://loinc.org",
               "code": "85354-9",
               "display": "Blood pressure panel with all children optional"
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "96607-7"
             }
           ],
           "text": "Blood pressure panel with all children optional"
@@ -32980,6 +32996,10 @@
                   "system": "http://loinc.org",
                   "code": "8462-4",
                   "display": "Diastolic Blood Pressure"
+                },
+                {
+                  "system": "http://loinc.org",
+                  "code": "96609-3"
                 }
               ],
               "text": "Diastolic Blood Pressure"
@@ -33002,6 +33022,10 @@
                   "system": "http://loinc.org",
                   "code": "8480-6",
                   "display": "Systolic Blood Pressure"
+                },
+                {
+                  "system": "http://loinc.org",
+                  "code": "96608-5"
                 }
               ],
               "text": "Systolic Blood Pressure"
@@ -33221,6 +33245,10 @@
               "system": "http://loinc.org",
               "code": "85354-9",
               "display": "Blood pressure panel with all children optional"
+            },
+            {
+              "system": "http://loinc.org",
+              "code": "96607-7"
             }
           ],
           "text": "Blood pressure panel with all children optional"
@@ -33244,6 +33272,10 @@
                   "system": "http://loinc.org",
                   "code": "8462-4",
                   "display": "Diastolic Blood Pressure"
+                },
+                {
+                  "system": "http://loinc.org",
+                  "code": "96609-3"
                 }
               ],
               "text": "Diastolic Blood Pressure"
@@ -33262,6 +33294,10 @@
                   "system": "http://loinc.org",
                   "code": "8480-6",
                   "display": "Systolic Blood Pressure"
+                },
+                {
+                  "system": "http://loinc.org",
+                  "code": "96608-5"
                 }
               ],
               "text": "Systolic Blood Pressure"

--- a/us-core-resources/e91975f5-9445-c11f-cabf-c3c6dae161f2.json
+++ b/us-core-resources/e91975f5-9445-c11f-cabf-c3c6dae161f2.json
@@ -97,22 +97,6 @@
                 }
               }
             ]
-          },
-          {
-            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex-for-clinical-use",
-            "extension": [
-              {
-                "url": "value",
-                "valueCodeableConcept": {
-                  "coding": [
-                    {
-                      "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-sex-for-clinical-use",
-                      "code": "male"
-                    }
-                  ]
-                }
-              }
-            ]
           }
         ],
         "identifier": [

--- a/us-core-resources/e91975f5-9445-c11f-cabf-c3c6dae161f2.json
+++ b/us-core-resources/e91975f5-9445-c11f-cabf-c3c6dae161f2.json
@@ -32297,9 +32297,6 @@
             "reference": "urn:uuid:706eb626-2e3a-4f23-bb58-dd11cde7da98"
           },
           {
-            "reference": "urn:uuid:17991da0-97b0-447c-bb49-185eb104a160"
-          },
-          {
             "reference": "urn:uuid:4b056f97-383a-416f-94a8-624972f4a440"
           }
         ],

--- a/us-core-resources/e91975f5-9445-c11f-cabf-c3c6dae161f2.json
+++ b/us-core-resources/e91975f5-9445-c11f-cabf-c3c6dae161f2.json
@@ -27659,6 +27659,15 @@
         "subject": {
           "reference": "urn:uuid:e91975f5-9445-c11f-cabf-c3c6dae161f2"
         },
+        "interpretation": {
+          "coding": [
+              {
+                  "code": "B",
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                  "display": "Better"
+              }
+          ]
+        },
         "encounter": {
           "reference": "urn:uuid:a438ddcc-b7e3-2049-7335-1012a274f19d"
         },
@@ -34270,6 +34279,9 @@
         "subject": {
           "reference": "urn:uuid:e91975f5-9445-c11f-cabf-c3c6dae161f2"
         },
+        "encounter": {
+          "reference": "urn:uuid:90a74c6c-a0e0-0cb3-157a-e38f35ca66b3"
+        },
         "authoredOn": "2015-03-30",
         "requester": {
           "reference": "urn:uuid:618787f5-2588-3dca-b90e-5e8fd27b1a36"
@@ -34412,103 +34424,6 @@
       "request": {
         "method": "POST",
         "url": "DocumentReference"
-      }
-    },
-    {
-      "fullUrl": "urn:uuid:17991da0-97b0-447c-bb49-185eb104a160",
-      "resource": {
-        "resourceType": "MedicationDispense",
-        "id": "17991da0-97b0-447c-bb49-185eb104a160",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationdispense"
-          ]
-        },
-        "identifier": [
-          {
-            "system": "https://github.com/inferno-framework/us-core-test-kit",
-            "value": "17991da0-97b0-447c-bb49-185eb104a160"
-          }
-        ],
-        "status": "completed",
-        "medicationCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-              "code": "476872",
-              "display": "Nizatidine 15 MG/ML Oral Solution"
-            }
-          ],
-          "text": "Nizatidine 15 MG/ML Oral Solution"
-        },
-        "subject": {
-          "reference": "urn:uuid:e91975f5-9445-c11f-cabf-c3c6dae161f2"
-        },
-        "performer": [
-          {
-            "actor": {
-              "reference": "urn:uuid:eb10a604-ac01-3975-ad58-4c34606af456",
-              "display": "Dr. Patricia625 Kilback373"
-            }
-          },
-          {
-            "actor": {
-              "reference": "urn:uuid:5d4b9df1-93ae-3bc9-b680-03249990e558",
-              "display": "HOLYOKE MEDICAL CENTER"
-            }
-          }
-        ],
-        "authorizingPrescription": [
-          {
-            "reference": "urn:uuid:1f50f7e0-ada9-752c-6cb6-9f4022f76c13",
-            "display": "Aspirin 81 MG Oral Tablet"
-          }
-        ],
-        "type": {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-              "code": "FFC",
-              "display": "First Fill - Complete"
-            }
-          ]
-        },
-        "quantity": {
-          "value": 480,
-          "unit": "mL",
-          "system": "http://unitsofmeasure.org",
-          "code": "mL"
-        },
-        "whenHandedOver": "2016-12-08T06:38:52Z",
-        "dosageInstruction": [
-          {
-            "text": "10 mL bid",
-            "timing": {
-              "repeat": {
-                "boundsPeriod": {
-                  "start": "2008-04-05"
-                },
-                "frequency": 2,
-                "period": 1,
-                "periodUnit": "d"
-              }
-            },
-            "doseAndRate": [
-              {
-                "doseQuantity": {
-                  "value": 10,
-                  "unit": "ml",
-                  "system": "http://unitsofmeasure.org",
-                  "code": "mL"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "request": {
-        "method": "POST",
-        "url": "MedicationDispense"
       }
     }
   ],

--- a/us-core-resources/e91975f5-9445-c11f-cabf-c3c6dae161f2.json
+++ b/us-core-resources/e91975f5-9445-c11f-cabf-c3c6dae161f2.json
@@ -18743,7 +18743,8 @@
             },
             {
               "system": "http://loinc.org",
-              "code": "96607-7"
+              "code": "96607-7",
+              "display": "Blood pressure panel mean systolic and mean diastolic"
             }
           ],
           "text": "Blood pressure panel with all children optional"
@@ -18767,7 +18768,8 @@
                 },
                 {
                   "system": "http://loinc.org",
-                  "code": "96609-3"
+                  "code": "96609-3",
+                  "display": "Diastolic blood pressure mean"
                 }
               ],
               "text": "Diastolic Blood Pressure"
@@ -18789,7 +18791,8 @@
                 },
                 {
                   "system": "http://loinc.org",
-                  "code": "96608-5"
+                  "code": "96608-5",
+                  "display": "Systolic blood pressure mean"
                 }
               ],
               "text": "Systolic Blood Pressure"
@@ -32962,10 +32965,6 @@
               "system": "http://loinc.org",
               "code": "85354-9",
               "display": "Blood pressure panel with all children optional"
-            },
-            {
-              "system": "http://loinc.org",
-              "code": "96607-7"
             }
           ],
           "text": "Blood pressure panel with all children optional"
@@ -32996,10 +32995,6 @@
                   "system": "http://loinc.org",
                   "code": "8462-4",
                   "display": "Diastolic Blood Pressure"
-                },
-                {
-                  "system": "http://loinc.org",
-                  "code": "96609-3"
                 }
               ],
               "text": "Diastolic Blood Pressure"
@@ -33022,10 +33017,6 @@
                   "system": "http://loinc.org",
                   "code": "8480-6",
                   "display": "Systolic Blood Pressure"
-                },
-                {
-                  "system": "http://loinc.org",
-                  "code": "96608-5"
                 }
               ],
               "text": "Systolic Blood Pressure"
@@ -33245,10 +33236,6 @@
               "system": "http://loinc.org",
               "code": "85354-9",
               "display": "Blood pressure panel with all children optional"
-            },
-            {
-              "system": "http://loinc.org",
-              "code": "96607-7"
             }
           ],
           "text": "Blood pressure panel with all children optional"
@@ -33272,10 +33259,6 @@
                   "system": "http://loinc.org",
                   "code": "8462-4",
                   "display": "Diastolic Blood Pressure"
-                },
-                {
-                  "system": "http://loinc.org",
-                  "code": "96609-3"
                 }
               ],
               "text": "Diastolic Blood Pressure"
@@ -33294,10 +33277,6 @@
                   "system": "http://loinc.org",
                   "code": "8480-6",
                   "display": "Systolic Blood Pressure"
-                },
-                {
-                  "system": "http://loinc.org",
-                  "code": "96608-5"
                 }
               ],
               "text": "Systolic Blood Pressure"


### PR DESCRIPTION
# Summary
Added elements to resources in the server to account for new mandatory/must support elements introduced in US Core 7.  Changes made to both initdb and the transaction jsons.
Added two of each of the new Observation profiles introduced in US Core 7
`sex-for-clinical-use` has been removed from Patient 355

## Testing guidance
Rebuild the server and run the following tests from US Core 7 test kit.  All tests should pass:
- 16.07 All must support elements are provided in the MedicationDispense resources returned
- 18.09 All must support elements are provided in the Observation resources returned
- 36.08 Observation resources returned during previous tests conform to the US Core Average Blood Pressure Profile
- 46.11 All must support elements are provided in the ServiceRequest resources returned
- 47.05 All must support elements are provided in the Specimen resources returned

All tests from 
- 24 "Observation Treatment Intervention Preference Tests"
- 25 "Observation Care Experience Preference Tests"
Should pass as well.


