### PR TITLE
Capability Statement patient-export Operation Bug Fix

### DIFF
--- a/src/main/resources/capability-statement-template.json
+++ b/src/main/resources/capability-statement-template.json
@@ -817,6 +817,12 @@
               "name": "name",
               "type": "string"
             }
+          ],
+          "operation": [
+            {
+              "name": "patient-export",
+              "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/patient-export"
+            }
           ]
         },
         {
@@ -846,12 +852,6 @@
             {
               "name": "identifier",
               "type": "token"
-            }
-          ],
-          "operation": [
-            {
-              "name": "patient-export",
-              "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/patient-export"
             }
           ]
         },


### PR DESCRIPTION
# Summary
Moved the patient-export operation from Practitioner resource to Patient resource in capability statement.

## New behavior
Capability statement now correctly lists the patient-export operation under the Capability Statement.

## Code changes
Changed capability statement template to move patient-export operation under Patient resource.

## Testing guidance
Run the reference server locally and ensure the Capability System returned by the server lists the patient-export operation under the Patient resource and not the Practitioner resource