### PR TITLE
FI-2366: Patient Export Operation Fix

### DIFF
--- a/src/main/java/org/mitre/fhir/MitreServerConfig.java
+++ b/src/main/java/org/mitre/fhir/MitreServerConfig.java
@@ -3,6 +3,7 @@ package org.mitre.fhir;
 import ca.uhn.fhir.jpa.api.config.DaoConfig;
 import ca.uhn.fhir.jpa.api.config.DaoConfig.ClientIdStrategyEnum;
 import ca.uhn.fhir.jpa.api.config.DaoConfig.IdStrategyEnum;
+import ca.uhn.fhir.jpa.api.config.DaoConfig.IndexEnabledEnum;
 import ca.uhn.fhir.jpa.batch.config.NonPersistedBatchConfigurer;
 import ca.uhn.fhir.jpa.bulk.export.job.GroupBulkItemReader;
 import ca.uhn.fhir.jpa.config.BaseJavaConfigR4;
@@ -54,6 +55,7 @@ public class MitreServerConfig extends BaseJavaConfigR4 {
     DaoConfig config = new DaoConfig();
     config.setAllowExternalReferences(true);
     config.getTreatBaseUrlsAsLocal().add("http://hl7.org/fhir/us/core/");
+    config.setIndexMissingFields(IndexEnabledEnum.ENABLED);
 
     // Auto-create placeholder reference targets to allow loading resources in any order
     config.setAutoCreatePlaceholderReferenceTargets(true);

--- a/src/main/resources/capability-statement-template.json
+++ b/src/main/resources/capability-statement-template.json
@@ -472,7 +472,7 @@
           "type": "Group",
           "operation": [
             {
-              "name": "group-export",
+              "name": "export",
               "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export"
             }
           ]
@@ -820,7 +820,7 @@
           ],
           "operation": [
             {
-              "name": "patient-export",
+              "name": "export",
               "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/patient-export"
             }
           ]

--- a/src/main/resources/capability-statement-template.json
+++ b/src/main/resources/capability-statement-template.json
@@ -817,6 +817,12 @@
               "name": "name",
               "type": "string"
             }
+          ],
+          "operation": [
+            {
+              "name": "patient-export",
+              "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/patient-export"
+            }
           ]
         },
         {
@@ -846,12 +852,6 @@
             {
               "name": "identifier",
               "type": "token"
-            }
-          ],
-          "operation": [
-            {
-              "name": "patient-export",
-              "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/patient-export"
             }
           ]
         },

--- a/src/main/resources/capability-statement-template.json
+++ b/src/main/resources/capability-statement-template.json
@@ -472,7 +472,7 @@
           "type": "Group",
           "operation": [
             {
-              "name": "export",
+              "name": "group-export",
               "definition": "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export"
             }
           ]


### PR DESCRIPTION
# Summary
The patient-export operation was listed under the Practitioner resource rather than the Patient resource in the capability statement, and the patient-export operation was not enabled on the server due to a specific setting, `IndexMissingFields` being disabled. This PR moves the patient-export operation to the correct resource in the Capability Statement (Patient), and it enables the IndexMissingFields setting so that the patient-export operation is enabled as well.

## New behavior
Bulk patient-export operation moved under Patient resource in capability statement, and patient-export operation is enabled on the server. 

## Code changes
Removed patient-export operation from Practitioner resource and moved under Patient resource in the Capability statement. set IndexMissingFields to enable to enable patient-export operation. 

## Testing guidance
Run server locally and make sure that you can make a request to the server using the patient-export operation. Make sure to change the `READ_ONLY` environment variable to `false` in `./docker-compose.yml`.