### PR TITLE
Dependabot updates + replace Derby database with H2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <hapi.version>5.5.3</hapi.version>
-    <jetty_version>9.4.52.v20230823</jetty_version>
+    <jetty_version>9.4.54.v20240208</jetty_version>
     <checkstyle.plugin.version>3.3.0</checkstyle.plugin.version>
     <checkstyle.version>10.12.4</checkstyle.version>
     <checkstyle.config>config/checkstyle/checkstyle.xml</checkstyle.config>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.0</version>
+      <version>1.4.14</version>
     </dependency>
 
     <!-- Required for JEE/Servlet support. -->
@@ -139,12 +139,14 @@
 		  <scope>test</scope>
 		</dependency>
 		
-		<!-- This example uses Derby embedded database for test cases. -->
-    <dependency>
-      <groupId>org.apache.derby</groupId>
-      <artifactId>derby</artifactId>
-      <version>10.14.2.0</version>
-    </dependency>
+		<!-- This example uses H2 embedded database for test cases. -->
+		<dependency>
+		    <groupId>com.h2database</groupId>
+		    <artifactId>h2</artifactId>
+		    <version>2.2.224</version>
+		    <scope>test</scope>
+		</dependency>
+
 
     <!-- for jwt support -->
     <dependency>

--- a/src/test/java/org/mitre/fhir/utils/HapiFhirH2Dialect.java
+++ b/src/test/java/org/mitre/fhir/utils/HapiFhirH2Dialect.java
@@ -1,0 +1,21 @@
+package org.mitre.fhir.utils;
+
+import org.hibernate.dialect.H2Dialect;
+
+/**
+ * HAPI FHIR dialect for H2 database.
+ * This class is cloned into Inferno until we update HAPI to get the real one.
+ * Original: 
+ * https://github.com/hapifhir/hapi-fhir/blob/d610d33ac361d3fc6e9d1624b40d7768e8371048/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/dialect/HapiFhirH2Dialect.java
+ */
+public class HapiFhirH2Dialect extends H2Dialect {
+
+    /**
+     * Workaround until this bug is fixed:
+     * https://hibernate.atlassian.net/browse/HHH-15002
+     */
+    @Override
+    public String toBooleanValueString(boolean bool) {
+        return bool ? "true" : "false";
+    }
+}

--- a/src/test/resources/hapi.properties
+++ b/src/test/resources/hapi.properties
@@ -1,9 +1,9 @@
-datasource.driver=org.apache.derby.jdbc.EmbeddedDriver
-datasource.url=jdbc:derby:directory:target/jpaserver_derby_files;create=true
+datasource.driver=org.h2.Driver
+datasource.url=dbc:h2:mem:in_memory_database_for_test
 datasource.username=
 datasource.password=
 datasource.max_pool_size=10
-hibernate.dialect=ca.uhn.fhir.jpa.util.DerbyTenSevenHapiFhirDialect
+hibernate.dialect=org.hibernate.dialect.H2Dialect
 hibernate.format_sql=false
 hibernate.show_sql=false
 hibernate.hbm2ddl.auto=update

--- a/src/test/resources/hapi.properties
+++ b/src/test/resources/hapi.properties
@@ -1,9 +1,10 @@
 datasource.driver=org.h2.Driver
-datasource.url=dbc:h2:mem:in_memory_database_for_test
+datasource.url=jdbc:h2:mem:in_memory_database_for_test
 datasource.username=
 datasource.password=
 datasource.max_pool_size=10
-hibernate.dialect=org.hibernate.dialect.H2Dialect
+hibernate.dialect=org.mitre.fhir.utils.HapiFhirH2Dialect
+# Note ^ is a backport of ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect which was added in a later version of HAPI
 hibernate.format_sql=false
 hibernate.show_sql=false
 hibernate.hbm2ddl.auto=update


### PR DESCRIPTION
# Summary
Replace the Derby DB which was only used for the unit test suite with [H2](https://www.h2database.com/) to address dependabot critical alerts. I would have preferred to just bump the Derby version but apparently the version with a fix either requires java 21 or a manual build of the dependency. 

This requires a custom "hibernate dialect" for H2 which is present in HAPI 5.7.9+ but we're still on 5.5, so I copied that class over.

Also bumps the logback version and jetty version at the same time to address other dependabot alerts.

## New behavior
None

## Code changes
See above

## Testing guidance
This change should have no visible impact. Note that the unit tests will fail if run on java 17+ - only java 11 seems to work at the moment. (also true on main)