### PR TITLE
FI-2492: Add Location.identifier and Location.type MS elements

### DIFF
--- a/resources/uscore_bundle_patient_85.json
+++ b/resources/uscore_bundle_patient_85.json
@@ -252,6 +252,24 @@
         },
         "status": "active",
         "name": "PCP87052",
+        "identifier": [
+          {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:uuid:690866aa-d2fd-8074-b448-3b7b0f1c84ad"
+          }
+        ],
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                "code": "ORTHO",
+                "display": "Orthopedics clinic"
+              }
+            ],
+            "text": "Orthopedics clinic"
+          }
+        ],
         "telecom": [
           {
             "system": "phone",


### PR DESCRIPTION
# Summary
Added `Location.identifier` and `Location.type` elements in support of US Core 7.0.0 MS requirements. This "PCP87052" Location appears to be the only one that the US Core 7 test actually finds so the fields were only added here.

## Testing guidance
Make sure to clear out the DB prior to running the reference server so the resources are reloaded, or alternatively set the `FORCE_LOAD_RESOURCES` env var to true.
> You can delete the server's data by stopping the containers with `docker-compose down` and then running `docker volume rm inferno-reference-server_fhir-pgdata` to remove the existing volume. 