### PR TITLE
FI-2605: SMART error responses should be json

### DIFF
--- a/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
+++ b/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
@@ -28,7 +28,9 @@ import java.util.Base64.Decoder;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -558,8 +560,8 @@ public class AuthorizationController {
    * @return error response content
    */
   @ExceptionHandler(OAuth2Exception.class)
-  public ResponseEntity<String> handleOAuth2Exception(OAuth2Exception ex) {
-    JSONObject json = new JSONObject();
+  public ResponseEntity<Map<String, String>> handleOAuth2Exception(OAuth2Exception ex) {
+    Map<String, String> json = new HashMap<>();
     json.put("error", ex.getError());
     if (ex.getErrorDescription() != null) {
       json.put("error_description", ex.getErrorDescription());
@@ -568,7 +570,7 @@ public class AuthorizationController {
               .status(ex.getResponseStatus())
               .contentType(MediaType.APPLICATION_JSON)
               .headers(ex.getResponseHeaders())
-              .body(json.toString());
+              .body(json);
   }
 
   private Encounter getFirstEncounterByPatientId(IGenericClient client, String patientId) {

--- a/src/main/java/org/mitre/fhir/authorization/exception/InvalidClientIdException.java
+++ b/src/main/java/org/mitre/fhir/authorization/exception/InvalidClientIdException.java
@@ -1,15 +1,23 @@
 package org.mitre.fhir.authorization.exception;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
 
-public class InvalidClientIdException extends ResponseStatusException {
-
-  private static final String ERROR_MESSAGE = "Invalid Client Id.";
+public class InvalidClientIdException extends OAuth2Exception {
 
   private static final long serialVersionUID = 1L;
 
-  public InvalidClientIdException(String clientId) {
-    super(HttpStatus.UNAUTHORIZED, ERROR_MESSAGE + " Supplied Client ID: \"" + clientId + "\"");
+  /**
+   * Create an InvalidClientIdException for the given clientID.
+   * @param clientId client_id that was supplied
+   * @param basicAuth Whether or not this client attempted to authenticate via the
+   *                  "Authorization" request header field. See
+   *                  https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+   */
+  public InvalidClientIdException(String clientId, boolean basicAuth) {
+    super(ErrorCode.INVALID_CLIENT, "Invalid Client Id. Supplied Client ID: \"" + clientId + "\"");
+    withResponseStatus(HttpStatus.UNAUTHORIZED);
+    if (basicAuth) {
+      withHeader("WWW-Authenticate", "Basic");
+    }
   }
 }

--- a/src/main/java/org/mitre/fhir/authorization/exception/InvalidClientSecretException.java
+++ b/src/main/java/org/mitre/fhir/authorization/exception/InvalidClientSecretException.java
@@ -1,14 +1,14 @@
 package org.mitre.fhir.authorization.exception;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
 
-public class InvalidClientSecretException extends ResponseStatusException {
+public class InvalidClientSecretException extends OAuth2Exception {
   private static final String ERROR_MESSAGE = "Client Secret invalid or not supplied";
 
   private static final long serialVersionUID = 1L;
 
   public InvalidClientSecretException() {
-    super(HttpStatus.UNAUTHORIZED, ERROR_MESSAGE);
+    super(OAuth2Exception.ErrorCode.INVALID_CLIENT, ERROR_MESSAGE);
+    withResponseStatus(HttpStatus.UNAUTHORIZED);
   }
 }

--- a/src/main/java/org/mitre/fhir/authorization/exception/OAuth2Exception.java
+++ b/src/main/java/org/mitre/fhir/authorization/exception/OAuth2Exception.java
@@ -1,0 +1,145 @@
+package org.mitre.fhir.authorization.exception;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Exception to represent errors in OAuth2 processes.
+ * See https://datatracker.ietf.org/doc/html/rfc6749#section-5.2 .
+ */
+public class OAuth2Exception extends RuntimeException {
+  private static final long serialVersionUID = 1L;
+  
+  private final String error;
+  private final String errorDescription;
+  
+  private HttpStatus responseStatus = HttpStatus.BAD_REQUEST;
+  private HttpHeaders responseHeaders;
+  
+  public OAuth2Exception(ErrorCode error) {
+    this(error, null, null);
+  }
+  
+  public OAuth2Exception(ErrorCode error, Throwable cause) {
+    this(error, cause.getMessage(), cause);
+  }
+  
+  public OAuth2Exception(ErrorCode error, String errorDescription) {
+    this(error, errorDescription, null);
+  }
+
+  /**
+   * Constructor for an OAuth2Exception with all fields.
+   * @param error The type of error
+   * @param errorDescription Additional text that may aid the recipient of the error
+   * @param cause The exception that caused this one, if any
+   */
+  public OAuth2Exception(ErrorCode error, String errorDescription, Throwable cause) {
+    super(cause);
+    this.error = error.toString().toLowerCase();
+    this.errorDescription = errorDescription;
+  }
+  
+  /**
+   * Set the HTTP response code that will be used when this exception is returned.
+   * Defaults to HttpStatus.BAD_REQUEST if not set.
+   * @param status HTTP Status
+   * @return this exception, for chaining
+   */
+  public OAuth2Exception withResponseStatus(HttpStatus status) {
+    if (status != null) {
+      this.responseStatus = status;
+    }
+    return this;
+  }
+  
+  /**
+   * Set the given key/value as a response header when this exception is returned.
+   * @param key Response header name
+   * @param value Response header value
+   * @return this exception, for chaining
+   */
+  public OAuth2Exception withHeader(String key, String value) {
+    if (this.responseHeaders == null) {
+      this.responseHeaders = new HttpHeaders();
+    }
+    this.responseHeaders.add(key, value);
+    return this;
+  }
+  
+  public String getError() {
+    return error;
+  }
+
+  public String getErrorDescription() {
+    return errorDescription;
+  }
+  
+  public HttpStatus getResponseStatus() {
+    return responseStatus;
+  }
+  
+  public HttpHeaders getResponseHeaders() {
+    return responseHeaders;
+  }
+
+  public static enum ErrorCode {
+    /**
+     * The request is missing a required parameter, includes an unsupported
+     * parameter value (other than grant type), repeats a parameter, includes
+     * multiple credentials, utilizes more than one mechanism for authenticating the
+     * client, or is otherwise malformed.
+     */
+    INVALID_REQUEST,
+
+    /**
+     * Client authentication failed (e.g., unknown client, no client authentication
+     * included, or unsupported authentication method). The authorization server MAY
+     * return an HTTP 401 (Unauthorized) status code to indicate which HTTP
+     * authentication schemes are supported. If the client attempted to authenticate
+     * via the "Authorization" request header field, the authorization server MUST
+     * respond with an HTTP 401 (Unauthorized) status code and include the
+     * "WWW-Authenticate" response header field matching the authentication scheme
+     * used by the client.
+     */
+    INVALID_CLIENT,
+
+    /**
+     * The provided authorization grant (e.g., authorization code, resource owner
+     * credentials) or refresh token is invalid, expired, revoked, does not match
+     * the redirection URI used in the authorization request, or was issued to
+     * another client.
+     */
+    INVALID_GRANT,
+
+    /**
+     * The authenticated client is not authorized to use this authorization grant
+     * type.
+     */
+    UNAUTHORIZED_CLIENT,
+
+    /**
+     * The authorization grant type is not supported by the authorization server.
+     */
+    UNSUPPORTED_GRANT_TYPE,
+
+    /**
+     * The requested scope is invalid, unknown, malformed, or exceeds the scope
+     * granted by the resource owner.
+     */
+    INVALID_SCOPE,
+
+
+    /**
+     * Used to indicate that the server failed to handle a valid request.
+     * NOTE:
+     * server_error is not technically valid for the "error" field on an error response
+     * from the /token endpoint, however there is no guidance on what should happen
+     * in these cases, and server_error is used for the authorization endpoint
+     * (since a redirect cannot return HTTP error codes)
+     */
+    SERVER_ERROR,
+
+  }
+  
+}

--- a/src/test/java/org/mitre/fhir/authorization/TestAuthorization.java
+++ b/src/test/java/org/mitre/fhir/authorization/TestAuthorization.java
@@ -46,6 +46,7 @@ import org.junit.Test;
 import org.mitre.fhir.authorization.exception.BearerTokenException;
 import org.mitre.fhir.authorization.exception.InvalidClientIdException;
 import org.mitre.fhir.authorization.exception.InvalidClientSecretException;
+import org.mitre.fhir.authorization.exception.OAuth2Exception;
 import org.mitre.fhir.authorization.token.Token;
 import org.mitre.fhir.authorization.token.TokenManager;
 import org.mitre.fhir.authorization.token.TokenNotFoundException;
@@ -57,7 +58,6 @@ import org.mitre.fhir.utils.exception.RsaKeyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.web.server.ResponseStatusException;
 
 public class TestAuthorization {
 
@@ -181,8 +181,8 @@ public class TestAuthorization {
 
       authorizationController.getToken("{\"code\":\"INVALID_CODE\"}", null, null, null, "authorization_code", null, null, null, request);
       Assert.fail("Did not get expected Unauthorized ResponseStatusException");
-    } catch (ResponseStatusException rse) {
-      if (!HttpStatus.UNAUTHORIZED.equals(rse.getStatus())) {
+    } catch (OAuth2Exception rse) {
+      if (!HttpStatus.UNAUTHORIZED.equals(rse.getResponseStatus())) {
         throw rse;
       }
     }
@@ -202,8 +202,8 @@ public class TestAuthorization {
 
       authorizationController.getToken(null, null, "SAMPLE_CLIENT_ID", null, "authorization_code", null, null, null, request);
       Assert.fail("Did not get expected Unauthorized ResponseStatusException");
-    } catch (ResponseStatusException rse) {
-      if (!HttpStatus.UNAUTHORIZED.equals(rse.getStatus())) {
+    } catch (OAuth2Exception rse) {
+      if (!HttpStatus.UNAUTHORIZED.equals(rse.getResponseStatus())) {
         throw rse;
       }
     }
@@ -436,7 +436,7 @@ public class TestAuthorization {
     );
   }
 
-  @Test(expected = ResponseStatusException.class)
+  @Test(expected = OAuth2Exception.class)
   public void testGetTokenNoPatientScopeProvided()
       throws JSONException, BearerTokenException, TokenNotFoundException {
     String serverBaseUrl = "";
@@ -686,7 +686,7 @@ public class TestAuthorization {
       authorizationController.getToken(FhirReferenceServerUtils.SAMPLE_CODE, null, null, null, "authorization_code", null,
           clientAssertionType, clientAssertion, request);
       Assert.fail("Token request should have thrown an exception for invalid signature");
-    } catch (ResponseStatusException e) {
+    } catch (OAuth2Exception e) {
       Assert.assertTrue(e.getCause() instanceof SignatureVerificationException); 
     }
   }
@@ -828,7 +828,7 @@ public class TestAuthorization {
     Assert.assertEquals(newPatientId, patientId);
   }
 
-  @Test(expected = ResponseStatusException.class)
+  @Test(expected = OAuth2Exception.class)
   public void testTestAuthorizationNoCodeAndNoRefreshToken()
       throws IOException, JSONException, BearerTokenException, TokenNotFoundException {
     AuthorizationController authorizationController = new AuthorizationController();
@@ -843,7 +843,7 @@ public class TestAuthorization {
       authorizationController.getToken(null, "SAMPLE_PUBLIC_CLIENT_ID", null, null, "authorization_code", null, null, null, request);
   }
 
-  @Test(expected = ResponseStatusException.class)
+  @Test(expected = OAuth2Exception.class)
   public void testTestAuthorizationInvalidRefreshToken()
       throws IOException, JSONException, BearerTokenException, TokenNotFoundException {
     AuthorizationController authorizationController = new AuthorizationController();
@@ -912,7 +912,7 @@ public class TestAuthorization {
       authorizationController.getToken(code, "SAMPLE_PUBLIC_CLIENT_ID", null, codeVerifier, "authorization_code", null, null, null, request);
   }
 
-  @Test(expected = ResponseStatusException.class)
+  @Test(expected = OAuth2Exception.class)
   public void testPKCERequiresValidCodeVerifier() throws IOException, JSONException, NoSuchAlgorithmException,
                                 BearerTokenException, TokenNotFoundException, TokenNotFoundException {
     AuthorizationController authorizationController = new AuthorizationController();
@@ -934,7 +934,7 @@ public class TestAuthorization {
       authorizationController.getToken(code, "SAMPLE_PUBLIC_CLIENT_ID", null, codeVerifier + "X", "authorization_code", null, null, null, request);
   }
 
-  @Test(expected = ResponseStatusException.class)
+  @Test(expected = OAuth2Exception.class)
   public void testPKCERequiresCodeVerifier() throws IOException, JSONException, NoSuchAlgorithmException,
                                 BearerTokenException, TokenNotFoundException, TokenNotFoundException {
     AuthorizationController authorizationController = new AuthorizationController();
@@ -956,7 +956,7 @@ public class TestAuthorization {
       authorizationController.getToken(code, "SAMPLE_PUBLIC_CLIENT_ID", null, null, "authorization_code", null, null, null, request);
   }
 
-  @Test(expected = ResponseStatusException.class)
+  @Test(expected = OAuth2Exception.class)
   public void testPKCERequiresCodeChallenge() throws IOException, JSONException, NoSuchAlgorithmException,
                                 BearerTokenException, TokenNotFoundException, TokenNotFoundException {
     AuthorizationController authorizationController = new AuthorizationController();
@@ -978,7 +978,7 @@ public class TestAuthorization {
       authorizationController.getToken(code, "SAMPLE_PUBLIC_CLIENT_ID", null, codeVerifier, "authorization_code", null, null, null, request);
   }
 
-  @Test(expected = ResponseStatusException.class)
+  @Test(expected = OAuth2Exception.class)
   public void testPKCERequiresS256() throws IOException, JSONException, NoSuchAlgorithmException,
                                 BearerTokenException, TokenNotFoundException, TokenNotFoundException {
     AuthorizationController authorizationController = new AuthorizationController();
@@ -998,7 +998,7 @@ public class TestAuthorization {
       authorizationController.getToken(code, "SAMPLE_PUBLIC_CLIENT_ID", null, codeVerifier, "authorization_code", null, null, null, request);
   }
 
-  @Test(expected = ResponseStatusException.class)
+  @Test(expected = OAuth2Exception.class)
   public void testPKCERequiredWithV2Scopes() throws IOException, JSONException,
       BearerTokenException, TokenNotFoundException, TokenNotFoundException {
     AuthorizationController authorizationController = new AuthorizationController();

--- a/src/test/java/org/mitre/fhir/authorization/TestAuthorizationWithNoData.java
+++ b/src/test/java/org/mitre/fhir/authorization/TestAuthorizationWithNoData.java
@@ -8,7 +8,6 @@ import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
 import com.github.dnault.xmlpatch.internal.Log;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.Base64;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.hl7.fhir.instance.model.api.IIdType;
@@ -20,12 +19,12 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mitre.fhir.authorization.exception.BearerTokenException;
+import org.mitre.fhir.authorization.exception.OAuth2Exception;
 import org.mitre.fhir.authorization.token.Token;
 import org.mitre.fhir.authorization.token.TokenManager;
 import org.mitre.fhir.utils.FhirReferenceServerUtils;
 import org.mitre.fhir.utils.TestUtils;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.web.server.ResponseStatusException;
 
 
 
@@ -43,7 +42,7 @@ public class TestAuthorizationWithNoData {
   private static Server ourServer;
   private static String ourServerBase;
 
-  @Test(expected = ResponseStatusException.class)
+  @Test(expected = OAuth2Exception.class)
   public void testGetTokenNoEncounterProvided() throws IOException, BearerTokenException {
     Patient pt = new Patient();
     pt.addName().setFamily("Test");
@@ -83,7 +82,7 @@ public class TestAuthorizationWithNoData {
         .execute();
   }
 
-  @Test(expected = ResponseStatusException.class)
+  @Test(expected = OAuth2Exception.class)
   public void testGetTokenNoPatientProvided() throws IOException, BearerTokenException {
     String serverBaseUrl = "";
     MockHttpServletRequest request = new MockHttpServletRequest();
@@ -113,7 +112,7 @@ public class TestAuthorizationWithNoData {
 
   }
 
-  @Test(expected = ResponseStatusException.class)
+  @Test(expected = OAuth2Exception.class)
   public void testGetTokenNoPatientOrEncounter() throws IOException, BearerTokenException {
 
     String serverBaseUrl = "";


### PR DESCRIPTION
# Summary
This PR changes the output format of errors raised on the `/authorization` endpoint to be JSON per the OAuth spec. https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
Previously these were rendered by the default spring error page, which meant they were HTML. (If the request came in with an `Accept: application/json` header it would return some JSON, but still not the expected format, and I don't think the spec requires that header)

## New behavior
There should be no changes in terms of pass/fail -- all requests that would previously succeed should still succeed with the exact same response, all requests that would previously return an error should still return an error, with the same http status and general string description of what went wrong. The main change is that errors will now always be of the form:

```json
{
  "error": "error_type",
  "error_description": "a short description here"
}
```

## Code changes
The key code change is just replacing the exceptions that are thrown and adding a new exception handler that renders them appropriately.  I created a new class `OAuth2Exception` which contains the error code, description, HTTP response code, and a header. (The header is only used for the specific instance of `invalid_client` when the client attempted to authenticate using basic auth, which per the spec is supposed to respond with a specific header.) The HTTP response code defaults to 400 Bad Request since this is what is used in the majority of cases.
There are a couple more specific exceptions already in the code, so to reduce changes I made these subclasses of the new OAuth2Exception. I could also remove these entirely and just use the new OAuth2Exception everywhere if people think that's cleaner.
In all cases the text of the error message should be the same, just the exception class changed.


Note the removal of the `if (!CLIENT_CREDENTIALS_GRANT_TYPE.equals(grantType)) {` block in the `getTokenByBackendServiceAuthorization` method is because that method is only ever called if the grant type is client_credentials, so that check would always be false.

## Testing guidance
All tests should pass/fail exactly as before. Some simple places to look at the error response are in the SMART App Launch test kit, STU2 test 3.2 "Authorization request fails when..."

Another easy option to test failure is to mess with the client assertion in the test kit, see https://github.com/inferno-framework/smart-app-launch-test-kit/blob/bfe00fa0a18bd29bf0ef600aa443e0ea511e1f50/lib/smart_app_launch/token_exchange_stu2_test.rb#L82 .