### PR TITLE
FI-2635: add asymmetric auth client info to landing page

### DIFF
--- a/src/main/java/org/mitre/fhir/landing/LandingViewController.java
+++ b/src/main/java/org/mitre/fhir/landing/LandingViewController.java
@@ -26,6 +26,7 @@ public class LandingViewController {
     model.addAttribute("publicClientId", properties.getPublicClientId());
     model.addAttribute("confidentialClientId", properties.getConfidentialClientId());
     model.addAttribute("confidentialClientSecret", properties.getConfidentialClientSecret());
+    model.addAttribute("asymmetricClientId", properties.getAsymmetricClientId());
     model.addAttribute("bulkClientId", properties.getBulkClientId());
     model.addAttribute("groupId", properties.getGroupId());
 

--- a/src/main/webapp/WEB-INF/templates/landing.html
+++ b/src/main/webapp/WEB-INF/templates/landing.html
@@ -64,7 +64,7 @@
 			</div>
 
 			<div class="form-group row">
-				<label for="clientId" class="col-sm-2 col-form-label">Public Client ID:</label>
+				<label for="publicClientId" class="col-sm-2 col-form-label">Public Client ID:</label>
 				<div class="col-sm-10">
 					<input type="text" readonly class="form-control-plaintext" id="publicClientId"
 						th:value="${publicClientId}">
@@ -72,7 +72,7 @@
 			</div>
 
 			<div class="form-group row">
-				<label for="clientId" class="col-sm-2 col-form-label">Confidential Client ID:</label>
+				<label for="confidentialClientId" class="col-sm-2 col-form-label">Confidential Client ID:</label>
 				<div class="col-sm-10">
 					<input type="text" readonly class="form-control-plaintext" id="confidentialClientId"
 						th:value="${confidentialClientId}">
@@ -81,10 +81,26 @@
 			</div>
 
 			<div class="form-group row">
-				<label for="clientSecret" class="col-sm-2 col-form-label">Confidential Client Secret:</label>
+				<label for="confidentialClientSecret" class="col-sm-2 col-form-label">Confidential Client Secret:</label>
 				<div class="col-sm-10">
-					<input type="text" readonly class="form-control-plaintext" id="confidentialClientId"
+					<input type="text" readonly class="form-control-plaintext" id="confidentialClientSecret"
 						th:value="${confidentialClientSecret}">
+				</div>
+			</div>
+
+			<div class="form-group row">
+				<label for="asymmetricClientId" class="col-sm-2 col-form-label">Asymmetric Client ID:</label>
+				<div class="col-sm-10">
+					<input type="text" readonly class="form-control-plaintext" id="asymmetricClientId"
+						th:value="${asymmetricClientId}">
+				</div>
+			</div>
+
+			<div class="form-group row">
+				<label for="asymmetricClientKey" class="col-sm-2 col-form-label">Asymmetric Client Key JWKS:</label>
+				<div class="col-sm-10">
+					<input type="text" readonly class="form-control-plaintext" id="asymmetricClientKey"
+						value="https://github.com/inferno-framework/smart-app-launch-test-kit/blob/main/lib/smart_app_launch/smart_jwks.json">
 				</div>
 			</div>
 


### PR DESCRIPTION
# Summary
Adds the confidential asymmetric client ID and key info to the landing page
![image](https://github.com/inferno-framework/inferno-reference-server/assets/13512036/17b5806a-766b-427b-b28b-d3e75efb3c44)

## Code changes
Added 2 new items to the landing page template. I noticed a couple of the other items in the list had what look like copy&paste dup IDs so I cleaned those up as well.

## Testing guidance
Landing page is at `http://localhost:8080/reference-server/`