### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,26 @@
   -->
   <dependencyManagement>
     <dependencies>
+      <!-- nested dependency of hapi-fhir-validation -->
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>1.26.1</version>
+      </dependency>
+
+      <!-- nested dependency of hapi-fhir-testpage-overlay -->
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-web</artifactId>
+        <version>6.1.6</version>
+      </dependency>
       
+      <!-- nested dependency of hapi-fhir-jpaserver-base -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot</artifactId>
+        <version>3.1.10</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
# Summary
Bumps the 3 dependencies noted in the current dependabot alerts to the latest available versions. Because these are nested dependencies, they are listed in the `dependencyManagement` section of the pom (see the comment a couple lines above the first added line).


## Testing guidance
If your local DB was built on a version of the reference-server prior to the HAPI 7 upgrade, make sure to delete it and let it be re-created. It won't hurt to delete the DB and start fresh either way
