### PR TITLE
remove prmitive extension from QuestionnaireResponse resources

### DIFF
--- a/resources/uscore_bundle_patient_85.json
+++ b/resources/uscore_bundle_patient_85.json
@@ -18481,18 +18481,7 @@
           "system": "urn:ietf:rfc:3986",
           "value": "urn:uuid:63c25911-a18e-4ccd-892a-8949c01d01b1"
         },
-        "_questionnaire" : {
-          "extension" : [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/display",
-              "valueString": "Glascow Coma Score"
-            },
-            {
-            "url" : "http://hl7.org/fhir/us/core/StructureDefinition/us-core-extension-questionnaire-uri",
-            "valueUri" : "https://www.cdc.gov/masstrauma/resources/gcs.pdf"
-            }
-          ]
-        },
+        "questionnaire" : "https://www.cdc.gov/masstrauma/resources/gcs",
         "status" : "completed",
         "subject" : {
           "reference" : "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
@@ -18888,14 +18877,7 @@
             "http://hl7.org/fhir/us/core/StructureDefinition/us-core-questionnaireresponse"
           ]
         },
-        "_questionnaire" : {
-          "extension" : [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/display",
-              "valueString": "Part of SDC-LOINC USSG Family History"
-            }
-          ]
-        },
+        "questionnaire" : "http://hl7.org/fhir/uv/sdc/Questionnaire/questionnaire-sdc-profile-example-ussg-fht|3.0",
         "status" : "completed",
         "subject" : {
           "reference" : "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"

--- a/resources/uscore_bundle_patient_85.json
+++ b/resources/uscore_bundle_patient_85.json
@@ -18877,7 +18877,7 @@
             "http://hl7.org/fhir/us/core/StructureDefinition/us-core-questionnaireresponse"
           ]
         },
-        "questionnaire" : "http://hl7.org/fhir/uv/sdc/Questionnaire/questionnaire-sdc-profile-example-ussg-fht|3.0",
+        "questionnaire" : "http://example.com/example-ussg-fht",
         "status" : "completed",
         "subject" : {
           "reference" : "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"


### PR DESCRIPTION
# Summary

This is a quick fix for an issue for loading QuestionnaireRepopnse resources into the HAPI server 7.0.1. Server rejects QuestionnireReponse resources with primitve extensions.

## New behavior

## Code changes

This PR replaces two `_questionnaire` primitive extensions  with regular `questionnaire` element.

## Testing guidance
