### PR TITLE
FI-2735: Restore previous url matching behavior - fixes landing page

### DIFF
--- a/src/main/java/org/mitre/fhir/InfernoReferenceServerWebConfig.java
+++ b/src/main/java/org/mitre/fhir/InfernoReferenceServerWebConfig.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
@@ -35,6 +36,17 @@ public class InfernoReferenceServerWebConfig implements WebMvcConfigurer {
     theRegistry.addResourceHandler("/fonts/**").addResourceLocations("/fonts/");
     theRegistry.addResourceHandler("/img/**").addResourceLocations("/img/");
     theRegistry.addResourceHandler("/js/**").addResourceLocations("/js/");
+  }
+
+  @Override
+  public void configurePathMatch(PathMatchConfigurer configurer) {
+    // This method restores the previous default setting,
+    // where a trailing slash may be ignored in path matching.
+    // eg: /page and /page/ will both resolve to the same mapping.
+    // Note that this setting is deprecated, and if it is eventually removed
+    // we will have to manually configure all relevant endpoints
+    // to match with or without a trailing slash.
+    configurer.setUseTrailingSlashMatch(true);
   }
 
   /**


### PR DESCRIPTION
# Summary
Fixes the landing page at /reference-server/ by restoring the previous trailing slash behavior.

## New behavior
Behavior should match previous behavior prior to the HAPI 7 upgrade in 3.0.0 -- URLs with or without a trailing slash should be handled the same.

## Code changes
Changed the `UseTrailingSlashMatch` setting to true to match what the default what prior to Spring 6.
Note: this setting is deprecated, but in the interest of a smaller change this is the easiest way to ensure things work how they used to. The alternative is to update all mappings to include both paths: with and without trailing slash. And I wasn't clear from the spec whether things like `./well-known/smart-configuration` should explicitly allow a trailing slash.

## Testing guidance
The main URL in question is http://localhost:8080/reference-server vs http://localhost:8080/reference-server/ . Everything else should continue to work as in prod today. 