### PR TITLE
Fix US Core 7 Observation for treatment intervention preference

### DIFF
--- a/resources/uscore_bundle_patient_85.json
+++ b/resources/uscore_bundle_patient_85.json
@@ -18062,10 +18062,10 @@
                 {
                     "system": "http://loinc.org",
                     "code": "75773-2",
-                    "display": "Goals, preferences, and priorities for medical treatment"
-                }
+                    "display": "Goals, preferences, and priorities for medical treatment [Reported]"
+                  }
             ],
-            "text": "Goals, preferences, and priorities for medical treatment"
+            "text": "Goals, preferences, and priorities for medical treatment [Reported]"
           },
           "subject": {
               "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
@@ -18112,10 +18112,10 @@
                 {
                     "system": "http://loinc.org",
                     "code": "75773-2",
-                    "display": "Goals, preferences, and priorities for medical treatment"
+                    "display": "Goals, preferences, and priorities for medical treatment [Reported]"
                 }
             ],
-            "text": "Goals, preferences, and priorities for medical treatment"
+            "text": "Goals, preferences, and priorities for medical treatment [Reported]"
           },
               "subject": {
               "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"

--- a/resources/uscore_bundle_patient_85.json
+++ b/resources/uscore_bundle_patient_85.json
@@ -18058,14 +18058,14 @@
               }
           ],
           "code": {
-              "coding": [
-                  {
-                      "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
-                      "code": "treatment-intervention-preference",
-                      "display": "Treatment Intervention Preference"
-                  }
-              ],
-              "text": "Treatment Intervention Preference"
+            "coding": [
+                {
+                    "system": "http://loinc.org",
+                    "code": "75773-2",
+                    "display": "Goals, preferences, and priorities for medical treatment"
+                }
+            ],
+            "text": "Goals, preferences, and priorities for medical treatment"
           },
           "subject": {
               "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
@@ -18108,16 +18108,16 @@
               }
           ],
           "code": {
-              "coding": [
-                  {
-                      "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
-                      "code": "treatment-intervention-preference",
-                      "display": "Treatment Intervention Preference"
-                  }
-              ],
-              "text": "Treatment Intervention Preference"
+            "coding": [
+                {
+                    "system": "http://loinc.org",
+                    "code": "75773-2",
+                    "display": "Goals, preferences, and priorities for medical treatment"
+                }
+            ],
+            "text": "Goals, preferences, and priorities for medical treatment"
           },
-          "subject": {
+              "subject": {
               "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
           },
           "effectiveDateTime": "2023-08-30",


### PR DESCRIPTION
# Summary

Original issue from: https://oncprojectracking.healthit.gov/support/browse/FI-2809

### Problem

Observation/6e828cbf-5651-4cf4-b410-258e02965ea4
Observation/22d4f19b-6add-44a4-ae68-1c38d5d9f7f0

have wrong codes for US Core 7

Change these Observation.code from

    "code": {
        "coding": [
            {
                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
                "code": "treatment-intervention-preference",
                "display": "Treatment Intervention Preference"
            }
        ],
        "text": "Treatment Intervention Preference"
    },

to

    "code": {
        "coding": [
            {
                "system": "http://loinc.org",
                "code": "75773-2",
                "display": "Goals, preferences, and priorities for medical treatment"
            }
        ],
        "text": "Goals, preferences, and priorities for medical treatment"
    },

## Testing guidance

Regenerate the database by 

`docker-compose build`

`docker-compose up`

Try the request below:

`http://localhost:8080/reference-server/r4/Observation?category=treatment-intervention-preference`

Check returned two Observations `17edaf4d-6a8f-4585-a6ab-2ed608e7bea2` `b46e58ec-b223-43cd-b200-c1c41815feb5` includes the code change above.


