### PR TITLE
FI-2867: New scope logic

### DIFF
--- a/src/main/resources/scope_parameters.yml
+++ b/src/main/resources/scope_parameters.yml
@@ -1,0 +1,15 @@
+---
+Condition:
+  - category=http://hl7.org/fhir/us/core/CodeSystem/condition-category|health-concern
+  - category=http://terminology.hl7.org/CodeSystem/condition-category|encounter-diagnosis
+  - category=http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item
+
+Observation:
+  - category=http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh
+  - category=http://terminology.hl7.org/CodeSystem-observation-category|social-history
+  - category=http://terminology.hl7.org/CodeSystem/observation-category|laboratory
+  - category=http://terminology.hl7.org/CodeSystem/observation-category|survey
+  - category=http://terminology.hl7.org/CodeSystem/observation-category|vital-signs
+
+DocumentReference:
+  - category=http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category|clinical-note

--- a/src/main/webapp/js/authorize.js
+++ b/src/main/webapp/js/authorize.js
@@ -3,8 +3,8 @@ window.mitre.fhirreferenceserver = window.mitre.fhirreferenceserver || {};
 window.mitre.fhirreferenceserver.authorize = {
 
   /**
-	 * initializes the page and all html components including actions
-	 */
+   * initializes the page and all html components including actions
+   */
   init: function () {
 
     // static code that the HAPI interceptor will look for to return token
@@ -88,8 +88,8 @@ window.mitre.fhirreferenceserver.authorize = {
 
     let scopes = urlParams.get('scope') || '';
 
-	let scopesData;
-	$.ajax({
+  let scopesData;
+  $.ajax({
           async: false,
           dataType: "json",
           data: JSON.stringify(scopes),
@@ -102,21 +102,21 @@ window.mitre.fhirreferenceserver.authorize = {
           }
         });
 
-    // load scopes
-    let checkBoxesHtml = '';
+  // load scopes
+  let checkBoxesHtml = '';
 
-	const createCheckbox = (scope, index, subscope=false) => {
-	  let scopeId = "scope-" + index;
-      return (
-          `<div class="form-check">
-             <input class="form-check-input ${subscope ? 'subscope' : 'main-scope'}" id="${scopeId}" name="scopeCheckbox" 
-                    type="checkbox" value="${scope}" ${subscope ? 'disabled' : 'checked'}>
-             <label class="form-check-label" for="${scopeId}">${scope}</label>
-           </div>`
-      );
-	}
+  const createCheckbox = (scope, index, subscope=false) => {
+    let scopeId = "scope-" + index;
+    return (
+      `<div class="form-check">
+         <input class="form-check-input ${subscope ? 'subscope' : 'main-scope'}" id="${scopeId}" name="scopeCheckbox" 
+                type="checkbox" value="${scope}" ${subscope ? 'disabled' : 'checked'}>
+         <label class="form-check-label" for="${scopeId}">${scope}</label>
+       </div>`
+    );
+  }
 
-	const scopeEntries = Object.entries(scopesData);
+  const scopeEntries = Object.entries(scopesData);
     for (let i = 0; i < scopeEntries.length; i++)
     {
       let [scope, subscopes] = scopeEntries[i];
@@ -124,9 +124,9 @@ window.mitre.fhirreferenceserver.authorize = {
       checkBoxesHtml += createCheckbox(scope, i);
 
       for (let j = 0; j < subscopes.length; j++) {
-		const subscope = subscopes[j];
-		checkBoxesHtml += createCheckbox(subscope, i + "-" + j, true);
-	  }
+        const subscope = subscopes[j];
+        checkBoxesHtml += createCheckbox(subscope, i + "-" + j, true);
+      }
     }
 
     $('#scopes').append(checkBoxesHtml);

--- a/src/test/resources/scope_parameters.yml
+++ b/src/test/resources/scope_parameters.yml
@@ -1,0 +1,11 @@
+---
+# NOTE: this test mapping is intentionally simplified and different from the real one
+
+Condition:
+  - category=health-concern
+  - category=encounter-diagnosis
+  - category=http://terminology.hl7.org/CodeSystem/condition-category|problem-list-item
+
+Observation:
+  - category=http://hl7.org/fhir/us/core/CodeSystem/us-core-category|sdoh
+  - category=http://terminology.hl7.org/CodeSystem-observation-category|social-history


### PR DESCRIPTION
# Summary
This PR introduces some special new logic related to granular scopes, and the interaction between SMART v1 and SMART v2 scopes.

## New behavior
1. When the client requests a resource-level scope, the user should be offered the alternative of selecting granular scopes instead. As currently implemented, the user should not be able to select both a resource-level scope and granular scope at the same time (though this can be easily bypassed by requesting multiple scopes in various ways)
2. If any SMART v2 scopes (such as the granular scopes introduced in 1) are selected, all scopes will be converted to SMART v2. This check happens both in the UI, so that the user can see live exactly what scope they will be granting, and in the backend to be safe.

## Code changes
- Added new `/supportedScopes` endpoint which is fetched by the UI. This endpoint takes the scopes that were requested, and responds with a list of details about the scopes that are offered. The UI parses this to display the checkboxes to the user.
- I've tried to minimize duplication in the UI and backend as much as possible in terms of scope parsing and converting.
- The set of search parameters that are appended to granular scopes are stored in a YAML file

## Testing guidance
Probably the easiest way to test this is with the US Core test kit. The SMART App Launch group at the start of the test allows you to enter the set of scopes you want, then you can view the scopes that were actually granted in test 1.3.2.06 "Token exchange response body contains required information encoded in JSON" . Use the SMART v1 test as-is to try out the switching versions back & forth based on which scopes are selected.