### PR TITLE
Bump nested dependency parsson to 1.0.5 [dependabot]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,13 @@
         <artifactId>spring-boot</artifactId>
         <version>3.1.10</version>
       </dependency>
+
+      <!-- nested dependency of elasticsearch via hapi-fhir-jpaserver-base -->
+      <dependency>
+        <groupId>org.eclipse.parsson</groupId>
+        <artifactId>parsson</artifactId>
+        <version>1.0.5</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
# Summary
Addresses dependabot security warning https://github.com/inferno-framework/inferno-reference-server/security/dependabot/101 - bumps the nested dependency `parsson` to the latest on the 1.0.x sequence as of today, 1.0.5

Unfortunately because this is a nested dependency, Dependabot cannot create this PR itself
![image](https://github.com/user-attachments/assets/40d043fc-e070-4c22-ad42-af10901e0dfb)

To see the dependency tree that shows where this dependency comes from, run `./mvnw dependency:tree` 

