### PR TITLE
Reference server data update for US Core 7 and HTI-1

### DIFF
--- a/resources/uscore_bundle_patient_355.json
+++ b/resources/uscore_bundle_patient_355.json
@@ -252,8 +252,25 @@
             "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
           ]
         },
+        "identifier":[
+          {
+            "system": "https://github.com/inferno-framework/us-core-test-kit",
+            "value": "ecd8399c-f381-beae-9a1c-afec249d4632"
+          }
+        ],
         "status": "active",
         "name": "PCP170967",
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                "code": "PC",
+                "display": "Primary care clinic"
+              }
+            ]
+          }
+        ],
         "telecom": [
           {
             "system": "phone",
@@ -958,8 +975,25 @@
             "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
           ]
         },
+        "identifier":[
+          {
+            "system": "https://github.com/inferno-framework/us-core-test-kit",
+            "value": "70b2a52f-71ba-6ffe-9050-5daee15f4d88"
+          }
+        ],
         "status": "active",
         "name": "HOLYOKE MEDICAL CENTER",
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                "code": "HOSP",
+                "display": "Hospital"
+              }
+            ]
+          }
+        ],
         "telecom": [
           {
             "system": "phone",
@@ -3254,8 +3288,25 @@
             "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
           ]
         },
+        "identifier": [
+          {
+            "system": "https://github.com/inferno-framework/us-core-test-kit",
+            "value": "4c34c0db-7434-8c8f-1936-30dd023babc2"
+          }
+        ],
         "status": "active",
         "name": "RIVER BEND MEDICAL GROUP - CHICOPEE OFFICE - URGENT CARE",
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                "code": "OF",
+                "display": "Outpatient facility"
+              }
+            ]
+          }
+        ],
         "telecom": [
           {
             "system": "phone",

--- a/resources/uscore_bundle_patient_355.json
+++ b/resources/uscore_bundle_patient_355.json
@@ -33820,12 +33820,7 @@
                 "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-tags",
                 "code": "sdoh",
                 "display": "SDOH"
-              }
-            ],
-            "text": "Social Determinants Of Health"
-          },
-          {
-            "coding": [
+              },
               {
                 "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
                 "code": "sdoh",
@@ -34164,6 +34159,11 @@
                 "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-tags",
                 "code": "sdoh",
                 "display": "SDOH"
+              },
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                "code": "sdoh",
+                "display": "SDOH"
               }
             ]
           }
@@ -34239,6 +34239,11 @@
                 "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-tags",
                 "code": "sdoh",
                 "display": "SDOH"
+              },
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                "code": "sdoh",
+                "display": "SDOH"
               }
             ]
           }
@@ -34306,6 +34311,11 @@
             "coding": [
               {
                 "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-tags",
+                "code": "sdoh",
+                "display": "SDOH"
+              },
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
                 "code": "sdoh",
                 "display": "SDOH"
               }

--- a/resources/uscore_bundle_patient_85.json
+++ b/resources/uscore_bundle_patient_85.json
@@ -17447,6 +17447,11 @@
                 "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-tags",
                 "code": "sdoh",
                 "display": "SDOH"
+              },
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
+                "code": "sdoh",
+                "display": "SDOH"
               }
             ]
           },
@@ -17524,6 +17529,11 @@
             "coding": [
               {
                 "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-tags",
+                "code": "sdoh",
+                "display": "SDOH"
+              },
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
                 "code": "sdoh",
                 "display": "SDOH"
               }
@@ -17641,6 +17651,11 @@
             "coding": [
               {
                 "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-tags",
+                "code": "sdoh",
+                "display": "SDOH"
+              },
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-category",
                 "code": "sdoh",
                 "display": "SDOH"
               }

--- a/resources/uscore_bundle_patient_85.json
+++ b/resources/uscore_bundle_patient_85.json
@@ -1610,6 +1610,12 @@
             "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole"
           ]
         },
+        "identifier":[
+          {
+            "system": "https://github.com/inferno-framework/us-core-test-kit",
+            "value": "8e81b028-5271-9eda-b6c0-0e308770ee50"
+          }
+        ],
         "practitioner": {
           "reference": "urn:uuid:8bee2ee3-d401-3728-9791-d235cfa01ab9",
           "display": "Dr. Willena258 Oberbrunner298"
@@ -1665,11 +1671,52 @@
             "use": "work"
           }
         ],
+        "endpoint": [
+          {
+            "reference": "urn:uuid:f85b5cca-bcf8-421c-bbcf-11db4dcb7e9c"
+          }
+        ],
         "resourceType": "PractitionerRole"
       },
       "request": {
         "method": "POST",
         "url": "PractitionerRole"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:f85b5cca-bcf8-421c-bbcf-11db4dcb7e9c",
+      "resource": {
+        "resourceType": "Endpoint",
+        "id": "f85b5cca-bcf8-421c-bbcf-11db4dcb7e9c",
+        "identifier": [
+          {
+            "system": "https://github.com/inferno-framework/us-core-test-kit",
+            "value": "f85b5cca-bcf8-421c-bbcf-11db4dcb7e9c"
+          }
+        ],
+        "status": "active",
+        "connectionType": {
+          "system": "http://terminology.hl7.org/CodeSystem/endpoint-connection-type",
+          "code": "direct-project",
+          "display": "Direct Project"
+        },
+        "payloadType": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/endpoint-payload-type",
+                "code": "any",
+                "display": "Any"
+              }
+            ],
+            "text": "Any"
+          }
+        ],
+        "address": "mailto:Willena258.Oberbrunner298@example.com"
+      },
+      "request": {
+        "method": "POST",
+        "url": "Endpoint"
       }
     },
     {
@@ -5457,8 +5504,14 @@
               },
               {
                 "url" : "informationSource",
-                "valueReference" : {
-                  "reference" : "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
+                "valueCodeableConcept" : {
+                  "coding": [
+                    {
+                      "system": "http://snomed.info/sct",
+                      "code": "116154003",
+                      "display": "Patient (person)"
+                    }
+                  ]
                 }
               }
             ],
@@ -16655,6 +16708,9 @@
           },
           {
             "reference": "urn:uuid:527fa5dd-9c4f-4e31-9ac8-36d3f9bd0e98"
+          },
+          {
+            "reference": "urn:uuid:f85b5cca-bcf8-421c-bbcf-11db4dcb7e9c"
           }
         ],
         "recorded": "1977-07-15T01:11:45.131-04:00",

--- a/resources/uscore_bundle_patient_85.json
+++ b/resources/uscore_bundle_patient_85.json
@@ -1457,8 +1457,25 @@
             "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
           ]
         },
+        "identifier": [
+          {
+            "system": "https://github.com/inferno-framework/us-core-test-kit",
+            "value": "8944e7cf-1482-b552-11a3-d3063d712d51"
+          }
+        ],
         "status": "active",
         "name": "LOWELL GENERAL HOSPITAL",
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                "code": "HOSP",
+                "display": "Hospital"
+              }
+            ]
+          }
+        ],
         "telecom": [
           {
             "system": "phone",

--- a/resources/uscore_bundle_patient_85.json
+++ b/resources/uscore_bundle_patient_85.json
@@ -675,15 +675,15 @@
             ]
           }
         ],
-        "code": {
-          "coding": [
+        "code" : {
+          "coding" : [
             {
-              "system": "http://loinc.org",
-              "code": "72166-2",
-              "display": "Tobacco smoking status"
+              "system" : "http://snomed.info/sct",
+              "code" : "401201003",
+              "display" : "Cigarette pack-years (observable entity)"
             }
           ],
-          "text": "Tobacco smoking status"
+          "text" : "Cigarette pack-years"
         },
         "subject": {
           "reference": "urn:uuid:d831ec91-c7a3-4a61-9312-7ff0c4a32134"
@@ -693,15 +693,11 @@
         },
         "effectiveDateTime": "1940-03-29T00:11:45-05:00",
         "issued": "1940-03-29T00:11:45.131-05:00",
-        "valueCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://snomed.info/sct",
-              "code": "266919005",
-              "display": "Never smoked"
-            }
-          ],
-          "text": "Never smoked"
+        "valueQuantity" : {
+          "value" : 26,
+          "unit" : "pack-years",
+          "system" : "http://unitsofmeasure.org",
+          "code" : "{pack-years}"
         },
         "resourceType": "Observation"
       },

--- a/resources/uscore_bundle_patient_85.json
+++ b/resources/uscore_bundle_patient_85.json
@@ -658,11 +658,6 @@
       "fullUrl": "urn:uuid:a2ad9c61-9e93-390e-34ad-d9d825c65a51",
       "resource": {
         "id": "a2ad9c61-9e93-390e-34ad-d9d825c65a51",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus"
-          ]
-        },
         "status": "final",
         "category": [
           {


### PR DESCRIPTION
# Summary
Fix reference server to be conforming to US Core 7 and HTI-1 
## New behavior

## Code changes
FI-2960: Add new sdoh category
FI-2876: PractitionerRole.endpoint MS element is missing
FI-2811: Add SmokingStatus Observation.valueQuantity
FI-2807: Fix MedicationRequest's medication_adherence extension
FI-2812: Populate MustSupport Location elements

## Testing guidance
Run US Core 7 test, all tests shall pass except:
* Observation Pregnancy validation test due to tx.fhir.org validation issue
* Simple Observation validation test due to tx.fhir.org validation issue
* Optional QuestionnaireResponse test due to missing data
