### PR TITLE
Bump bootstrap and nested dependency graphql [dependabot]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
 		<dependency>
 			<groupId>org.webjars.npm</groupId>
 			<artifactId>bootstrap</artifactId>
-			<version>4.6.0</version>
+			<version>4.6.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars.npm</groupId>
@@ -263,6 +263,13 @@
         <groupId>org.eclipse.parsson</groupId>
         <artifactId>parsson</artifactId>
         <version>1.0.5</version>
+      </dependency>
+
+      <!-- nested dependency of hapi-fhir-jpaserver-base -->
+      <dependency>
+        <groupId>com.graphql-java</groupId>
+        <artifactId>graphql-java</artifactId>
+        <version>21.5</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
# Summary
Bumps two dependencies to address dependabot warnings:
- graphql-java is a nested dependency of hapi-fhir-jpaserver-base, bumped to the highest 21.x version as of today
- bootstrap is a direct dependency; the dependabot warning says use > 3.4.0 or > 4.1.2 so this should already be ok but this bumps it to the latest 4.x version as of today while I'm here
