### PR TITLE
Enable docker hub workflow

### DIFF
--- a/.github/workflows/docker_hub_build.yml
+++ b/.github/workflows/docker_hub_build.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
     tags:
       - 'v*.*.*'
 


### PR DESCRIPTION
# Summary

Any update to main or a tagged version will push a new release to Docker hub. **GitHub secrets must be valid for this to work**

## New behavior

Adds CI workflow.

## Code changes

See `.github/workflows/docker_hub_build.yml`

## Testing guidance

Examine CI workflow and check release on Docker hub after merge.