### PR TITLE
FI-3258: Add CORS support per SMART 2.2

### DIFF
--- a/src/main/java/org/mitre/fhir/MitreServerConfig.java
+++ b/src/main/java/org/mitre/fhir/MitreServerConfig.java
@@ -23,12 +23,10 @@ import ca.uhn.fhir.jpa.subscription.channel.config.SubscriptionChannelConfig;
 import ca.uhn.fhir.jpa.subscription.match.deliver.email.IEmailSender;
 import ca.uhn.fhir.jpa.validation.JpaValidationSupportChain;
 import ca.uhn.fhir.rest.api.IResourceSupportedSvc;
-import ca.uhn.fhir.rest.server.interceptor.CorsInterceptor;
 import ca.uhn.fhir.rest.server.interceptor.ResponseHighlighterInterceptor;
 import ca.uhn.fhir.rest.server.util.ISearchParamRegistry;
 import jakarta.persistence.EntityManagerFactory;
 import java.sql.Driver;
-import java.util.Arrays;
 import java.util.Properties;
 import javax.sql.DataSource;
 import org.apache.commons.dbcp2.BasicDataSource;
@@ -41,11 +39,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
-import org.springframework.http.HttpHeaders;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
-import org.springframework.web.cors.CorsConfiguration;
 
 /**
  * Configures the Server and Database.
@@ -168,31 +164,6 @@ public class MitreServerConfig {
         "LUCENE_CURRENT");
 
     return extraProperties;
-  }
-  
-  /**
-   * Define the CORS settings for this server.
-   * In this case we allow all origins and methods.
-   */
-  @Bean
-  public CorsInterceptor corsInterceptor() {
-    CorsConfiguration config = new CorsConfiguration();
-    config.addAllowedHeader(HttpHeaders.ORIGIN);
-    config.addAllowedHeader(HttpHeaders.ACCEPT);
-    config.addAllowedHeader(HttpHeaders.CONTENT_TYPE);
-    config.addAllowedHeader(HttpHeaders.AUTHORIZATION);
-    config.addAllowedHeader(HttpHeaders.CACHE_CONTROL);
-    config.addAllowedHeader("x-fhir-starter");
-    config.addAllowedHeader("X-Requested-With");
-    config.addAllowedHeader("Prefer");
-    config.addAllowedOrigin("*");
-    config.addExposedHeader("Location");
-    config.addExposedHeader("Content-Location");
-    config.setAllowedMethods(
-        Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH", "HEAD"));
-    config.setAllowCredentials(true);
-
-    return new CorsInterceptor(config);
   }
 
   @Bean

--- a/src/main/java/org/mitre/fhir/PathBasedCorsInterceptor.java
+++ b/src/main/java/org/mitre/fhir/PathBasedCorsInterceptor.java
@@ -1,0 +1,121 @@
+package org.mitre.fhir;
+
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.interceptor.InterceptorAdapter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.PathContainer;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsProcessor;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.cors.DefaultCorsProcessor;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+/**
+ * Adapted from ca.uhn.fhir.rest.server.interceptor.CorsInterceptor
+ * Modified to allow different configuration based on URL
+ */
+public class PathBasedCorsInterceptor extends InterceptorAdapter {
+
+  private final CorsProcessor corsProcessor;
+  private LinkedHashMap<String, CorsConfiguration> config;
+
+  
+  public PathBasedCorsInterceptor(LinkedHashMap<String, CorsConfiguration> config) {
+    corsProcessor = new DefaultCorsProcessor();
+    this.config = config;
+  }
+  
+  static boolean pathMatches(PathContainer requestUri, String configuredPath) {
+    PathPattern parsedConfiguredPath = PathPatternParser.defaultInstance.parse(configuredPath);
+    return parsedConfiguredPath.matches(requestUri);
+  }
+  
+  static boolean pathMatches(String requestUri, String configuredPath) {
+    return pathMatches(PathContainer.parsePath(requestUri), configuredPath);
+  }
+  
+  @Override
+  public boolean incomingRequestPreProcessed(HttpServletRequest req, HttpServletResponse resp) {
+    if (CorsUtils.isCorsRequest(req)) {
+      boolean isValid = true;
+      try {
+        PathContainer uri = PathContainer.parsePath(req.getRequestURI());
+        for (String path : config.keySet()) {
+          if (pathMatches(uri, path)) {
+            isValid = corsProcessor.processRequest(config.get(path), req, resp);
+            break;
+          }
+        }
+      } catch (IOException e) {
+        // TODO: investigate what might cause an exception. For now just 500 error
+        throw new InternalErrorException("Exception occurred in CORS handling", e);
+      }
+      if (!isValid || CorsUtils.isPreFlightRequest(req)) {
+        return false;
+      }
+    }
+
+    return super.incomingRequestPreProcessed(req, resp);
+  }
+
+  /**
+   * Helper method for a CorsConfiguration with common options pre-configured.
+   * Note this does not set any Allowed-Origin options, callers must set that.
+   */
+  public static CorsConfiguration baseConfig() {
+    CorsConfiguration config = new CorsConfiguration();
+    config.addAllowedHeader(HttpHeaders.ORIGIN);
+    config.addAllowedHeader(HttpHeaders.ACCEPT);
+    config.addAllowedHeader(HttpHeaders.CONTENT_TYPE);
+    config.addAllowedHeader(HttpHeaders.AUTHORIZATION);
+    config.addAllowedHeader(HttpHeaders.CACHE_CONTROL);
+    config.addAllowedHeader("x-fhir-starter");
+    config.addAllowedHeader("X-Requested-With");
+    config.addAllowedHeader("Prefer");
+    config.addExposedHeader("Location");
+    config.addExposedHeader("Content-Location");
+    config.setAllowedMethods(
+        Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH", "HEAD"));
+
+    return config;
+  }
+  
+  /**
+   * Helper function to create a CorsConfiguration for public "discovery" type endpoints.
+   * This is intended to allow access from any origin.
+   */
+  public static CorsConfiguration publicDiscoveryEndpointConfig() {
+    CorsConfiguration publicDiscoveryEndpointConfig = baseConfig();
+    
+    // using "Allowed Origin" here results in the literal response
+    // Access-Control-Allow-Origin: *
+    publicDiscoveryEndpointConfig.addAllowedOrigin("*");
+    
+    // this is the default, but making it explicit here
+    publicDiscoveryEndpointConfig.setAllowCredentials(false);
+    return publicDiscoveryEndpointConfig;
+  }
+  
+  /**
+   * Helper function to create a CorsConfiguration for private or API endpoints,
+   * where access should only be allowed from registered client origins.
+   */
+  public static CorsConfiguration privateApiEndpointConfig() {
+    CorsConfiguration privateApiEndpointConfig = baseConfig();
+    
+    // using "Allowed Origin Pattern" here results in
+    // the Origin field from the request being echoed back in the response, ex:
+    // Access-Control-Allow-Origin: http://localhost:4567
+    privateApiEndpointConfig.addAllowedOriginPattern("*");
+    
+    privateApiEndpointConfig.setAllowCredentials(true);
+    return privateApiEndpointConfig;
+  }
+  
+}

--- a/src/main/java/org/mitre/fhir/app/launch/AppLaunchController.java
+++ b/src/main/java/org/mitre/fhir/app/launch/AppLaunchController.java
@@ -1,6 +1,5 @@
 package org.mitre.fhir.app.launch;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.ArrayList;

--- a/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
+++ b/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
@@ -57,6 +57,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -67,6 +68,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.yaml.snakeyaml.Yaml;
 
 @RestController
+@CrossOrigin(originPatterns = {"*"}, exposedHeaders = {"*"}, allowCredentials = "true")
 public class AuthorizationController {
 
   private static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";

--- a/src/main/java/org/mitre/fhir/authorization/token/TokenController.java
+++ b/src/main/java/org/mitre/fhir/authorization/token/TokenController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.json.JSONObject;
 import org.mitre.fhir.utils.FhirReferenceServerUtils;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,6 +15,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/token")
+@CrossOrigin(originPatterns = {"*"}, exposedHeaders = {"*"}, allowCredentials = "true")
 public class TokenController {
   /**
    * Service to revoke a token.

--- a/src/main/java/org/mitre/fhir/wellknown/WellKnownAuthorizationEndpointController.java
+++ b/src/main/java/org/mitre/fhir/wellknown/WellKnownAuthorizationEndpointController.java
@@ -14,11 +14,13 @@ import org.mitre.fhir.utils.FhirReferenceServerUtils;
 import org.mitre.fhir.utils.RsaUtils;
 import org.mitre.fhir.utils.exception.RsaKeyException;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Configuration
 @RestController
+@CrossOrigin(origins = {"*"}, allowCredentials = "false")
 public class WellKnownAuthorizationEndpointController {
 
   private static final String WELL_KNOWN_AUTHORIZATION_ENDPOINT_KEY = "authorization_endpoint";


### PR DESCRIPTION
# Summary
Enables CORS on the reference server per SMART 2.2: https://hl7.org/fhir/smart-app-launch/STU2.2/app-launch.html#considerations-for-cross-origin-resource-sharing-cors-support

> Servers that support purely browser-based apps SHALL enable [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) as follows:
> * For requests from any origin, CORS configuration permits access to the public discovery endpoints (.well-known/smart-configuration and metadata)
> * For requests from a client’s registered origin(s), CORS configuration permits access to the token endpoint and to FHIR REST API endpoints

In this case, we don't really want to implement a full client registration process, so we interpret the current Origin field as a client's "registered origin".

## New behavior
CORS headers should now appear on responses from pretty much all endpoints. I say "pretty much" because I didn't add CORS settings to all of our controllers such as the launch controllers which I don't think need them. I can easily add them if we want to do that.

As noted above, there are two categories of endpoints: the "public" discovery endpoints and "private" API endpoints. Responses from "public" endpoints will receive the header `Access-Control-Allow-Origin: *` (with the literal * wildcard). Responses from "private" endpoints will receive the header `Access-Control-Allow-Origin: <Origin from request>` where the value is the value of the Origin field in the request echoed back. 

## Code changes
There was a CORS interceptor bean previously in MitreServerConfig but it didn't actually do anything. The settings from that were copied as the basis for the new "PathBasedCorsInterceptor" class - this class allows for different CORS settings based on URL. 

Unfortunately the Interceptor is a HAPI concept so it only applies on HAPI-managed endpoints. For our controllers (specifically here, the controllers behind the `/token` and `/.well-known/*` endpoints) I add the Spring `@CrossOrigin` annotation with appropriate settings:

`@CrossOrigin(origins = {"*"}, allowCredentials = "false")` for "public" endpoints

`@CrossOrigin(originPatterns = {"*"}, exposedHeaders = {"*"}, allowCredentials = "true")` for "private" endpoints

(I really wanted to find a global approach for CORS so we didn't have to implement it per-controller and separately for HAPI, but the suggestions I found, eg https://spring.io/blog/2015/06/08/cors-support-in-spring-framework , I couldn't get to work)

## Testing guidance
CORS tests are being added to the SMART test kit in this PR: https://github.com/inferno-framework/smart-app-launch-test-kit/pull/75
You can also test the http responses directly with something like Postman (I use Bruno https://github.com/usebruno/bruno because it doesn't require an account)

## Open questions
 - Do we want an env var or any kind of config setting to "disable" CORS or have other options along those lines? In practice this should be as permissive today as previously