### PR TITLE
Fix Observation Social History/Pregnancy Intent code

### DIFF
--- a/resources/uscore_bundle_patient_85.json
+++ b/resources/uscore_bundle_patient_85.json
@@ -17975,7 +17975,8 @@
             {
               "system": "http://snomed.info/sct",
               "code": "454381000124105",
-              "display": "Not sure of desire to become pregnant (finding)"
+              "display": "Not sure of desire to become pregnant (finding)",
+              "version" : "http://snomed.info/sct/731000124108"
             }
           ]
         }


### PR DESCRIPTION
# Summary

Added SNOMED version `http://snomed.info/sct/731000124108` to the Observation resource.

## New behavior

US Core v5.0.1 passes Observation Social Hx test group, and both US Core v6.1.0, v7.0.0 pass Observation Pregnancy Intent test group.

## Code changes

See diff. 

## Testing guidance

1. Checkout this branch.
2. Reset and run reference server:
```
docker compose down
docker volume rm inferno-reference-server_fhir-pgdata
docker compose build
docker compose up
```
3. Run US Core v5.0.1, v6.1.0, v7.0.0 with input patient ids 85,355