### PR TITLE
FI-3044: Enforce the appropriate auth mechanism for each client

### DIFF
--- a/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
+++ b/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
@@ -335,7 +335,7 @@ public class AuthorizationController {
     }
 
     authorizeClientId(clientId, basicHeader != null);
-    authenticateClientIdAndClientSecret(clientId, clientSecret);
+    authenticateClient(clientId, basicHeader, clientAssertionType, clientAssertion, clientSecret);
 
     return clientId;
   }
@@ -740,12 +740,44 @@ public class AuthorizationController {
     }
   }
 
-  private static void authenticateClientIdAndClientSecret(String clientId, String clientSecret) {
+  /**
+   * Authenticate the client based on the provided credentials,
+   * enforcing the expected authentication mechanism per client.
+   */
+  private static void authenticateClient(String clientId, String basicHeader,
+      String clientAssertionType, String clientAssertion, String clientSecret) {
     HapiReferenceServerProperties properties = new HapiReferenceServerProperties();
-    if (properties.getConfidentialClientId().equals(clientId)
-        && !properties.getConfidentialClientSecret().equals(clientSecret)) {
-      throw new InvalidClientSecretException();
+
+    // note we've called authorizeClientId already
+    // so the only possible options here for clientId are our 3 predefined choices
+
+    if (properties.getConfidentialClientId().equals(clientId)) {
+      // confidential symmetric -- uses authorization header/basic auth
+      if (basicHeader == null
+          || !properties.getConfidentialClientSecret().equals(clientSecret)) {
+        // Client Secret invalid or not supplied
+        throw new InvalidClientSecretException();
+      }
+    } else if (properties.getAsymmetricClientId().equals(clientId)) {
+      // confidential asymmetric -- uses a signed JWT in the client_assertion
+
+      // actual validation of the client assertion was done previously
+      // if it was provided, so here just check that it was provided
+      if (!JWT_BEARER_CLIENT_ASSERTION_TYPE.equals(clientAssertionType)
+          || clientAssertion == null || clientAssertion.isBlank()) {
+        throw new OAuth2Exception(ErrorCode.INVALID_CLIENT,
+            "Client assertion invalid or not supplied")
+            .withResponseStatus(HttpStatus.UNAUTHORIZED);
+      }
+    } else if (properties.getPublicClientId().equals(clientId)) {
+      // public app; safeguarding secrets is not possible
+      // and so credentials should not be provided
+
+      if (basicHeader != null || clientAssertionType != null) {
+        throw new OAuth2Exception(ErrorCode.INVALID_CLIENT,
+            "Public clients may not provide secrets or assertions")
+            .withResponseStatus(HttpStatus.UNAUTHORIZED);
+      }
     }
   }
-
 }

--- a/src/test/java/org/mitre/fhir/authorization/TestAuthorization.java
+++ b/src/test/java/org/mitre/fhir/authorization/TestAuthorization.java
@@ -211,8 +211,6 @@ public class TestAuthorization {
     request.setLocalAddr("localhost");
     request.setRequestURI(serverBaseUrl);
     request.setServerPort(TestUtils.TEST_PORT);
-    request.addHeader("Authorization",
-        TestUtils.getEncodedBasicAuthorizationHeaderWithPublicClient());
 
     String scopes = "launch/patient openId ";
     String code =

--- a/src/test/java/org/mitre/fhir/utils/TestUtils.java
+++ b/src/test/java/org/mitre/fhir/utils/TestUtils.java
@@ -19,17 +19,12 @@ public class TestUtils {
 
   public static final int TEST_PORT = 1234;
   
-  private static final String SAMPLE_PUBLIC_CLIENT_ID = "SAMPLE_PUBLIC_CLIENT_ID";
   private static final String SAMPLE_CONFIDENTIAL_CLIENT_ID = "SAMPLE_CONFIDENTIAL_CLIENT_ID";
   private static final String SAMPLE_CONFIDENTIAL_CLIENT_SECRET =
       "SAMPLE_CONFIDENTIAL_CLIENT_SECRET";
 
   public static String getBasicAuthorizationString(String clientId, String clientSecret) {
     return clientId + ":" + clientSecret;
-  }
-
-  public static String getEncodedBasicAuthorizationHeaderWithPublicClient() {
-    return getEncodedBasicAuthorizationHeader(SAMPLE_PUBLIC_CLIENT_ID, "");
   }
   
   /**


### PR DESCRIPTION
# Summary
The reference server has 3 conceptual clients - public, confidential asymmetric, and confidential symmetric. Previously the only authentication performed was checking the client secret if the ID provided was the confidential symmetric id, but it was possible to use the public or confidential asymmetric clients with any client secret, or the confidential asymmetric client without a client assertion. This PR enforces the appropriate auth mechanism for each client.  

This issue was identified on g10, which originally wasn't sending the token request correctly. The corresponding fix there was https://github.com/onc-healthit/onc-certification-g10-test-kit/pull/549 which was included in v6.0.1 (or in other words, the last version without the fix is v6.0.0) 

## New behavior
Clients can only authenticate with the appropriate mechanism.
More specifically this means that public clients may no longer provide credentials and confidential asymmetric clients must provide the appropriate client assertion. The server was already validating the assertion if it was provided, so what's new is just checking that it's there at all.

## Code changes
There's an existing function that checked the confidential symmetric client secret - added the extra logic there.

Also updated a unit test because for some reason it was putting the client id in the Authorization header for a public client, and that's not supposed to be there. (https://build.fhir.org/ig/HL7/smart-app-launch/example-app-launch-public.html#step-2-launch)

## Testing guidance
Run the g10 test suite and everything should pass (minus the expected TLS tests running locally) with the reference server preset but change the server endpoint to your local running instance. The key tests/groups to confirm are:
 - 1.4.05 (uses confidential symmetric client)
 - 9.2.05 (public client)
 - 9.12.2.05 (confidential asymmetric client)
   - this is the test that fails on the prod reference server today
   - on the other hand, the version of g10 prior to its corresponding fix (v6.0.0) will fail running against this updated server and pass prod today

These tests should also fail if you swap the client IDs around in the test config, for example, if you specify `SAMPLE_ASYMMETRIC_CLIENT_ID` (with any secret) as the Standalone Client ID in test group 1, it will pass on prod today but the token request should fail here with a 401