### PR TITLE
FI-3368 Update link to inferno test kit tutorial

### DIFF
--- a/src/main/webapp/WEB-INF/templates/landing.html
+++ b/src/main/webapp/WEB-INF/templates/landing.html
@@ -153,7 +153,7 @@
 			</li>
 			<li>
 				<a
-					href="https://github.com/inferno-training/inferno-tutorial/wiki/1.-Accepting-User-Bearer-Token-Input#reference-servers-to-test-against">Reference
+					href="https://github.com/inferno-framework/tutorial-test-kit/wiki/1.-Accepting-User-Bearer-Token-Input#reference-servers-to-test-against">Reference
 					Server Training</a>
 			</li>
 		</ul>


### PR DESCRIPTION
# Summary
Inferno Test Kit Authoring tutorial moved to /inferno-framework. Update link on the reference serve landing page.

## New behavior
Link should point to https://github.com/inferno-framework/tutorial-test-kit/wiki 
## Code changes

## Testing guidance
