### PR TITLE
FI-3191: Bump HAPI to v7.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <hapi.version>7.0.2</hapi.version>
+    <hapi.version>7.6.0</hapi.version>
     <jetty_version>12.0.8</jetty_version>
     <checkstyle.plugin.version>3.3.1</checkstyle.plugin.version>
     <checkstyle.version>10.15.0</checkstyle.version>
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.3.10</version>
+      <version>42.7.4</version>
     </dependency>
 
     <dependency>
@@ -134,7 +134,7 @@
 	<dependency>
 	  <groupId>com.h2database</groupId>
 	  <artifactId>h2</artifactId>
-	  <version>2.2.224</version>
+	  <version>2.3.232</version>
 	  <scope>test</scope>
 	</dependency>
 
@@ -169,7 +169,7 @@
 		<dependency>
 			<groupId>org.webjars.npm</groupId>
 			<artifactId>bootstrap</artifactId>
-			<version>4.6.0</version>
+			<version>4.6.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars.npm</groupId>
@@ -237,20 +237,6 @@
   -->
   <dependencyManagement>
     <dependencies>
-      <!-- nested dependency of hapi-fhir-validation -->
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-compress</artifactId>
-        <version>1.26.1</version>
-      </dependency>
-
-      <!-- nested dependency of hapi-fhir-testpage-overlay -->
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-web</artifactId>
-        <version>6.1.6</version>
-      </dependency>
-      
       <!-- nested dependency of hapi-fhir-jpaserver-base -->
       <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -258,11 +244,10 @@
         <version>3.1.10</version>
       </dependency>
 
-      <!-- nested dependency of elasticsearch via hapi-fhir-jpaserver-base -->
       <dependency>
-        <groupId>org.eclipse.parsson</groupId>
-        <artifactId>parsson</artifactId>
-        <version>1.0.5</version>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>3.25.5</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
# Summary
Bumps HAPI to v7.6.0, just released a few days ago. Also bumps a couple other dependencies to their most recent versions. This should address most, hopefully all, of the high-priority dependabot alerts. Unfortunately that only updates when there's a push to main, so there may be a second PR after this to address further alerts.

## New behavior
Nothing should be new or different.

## Code changes
The items in dependencyManagement are changed as follows:
- commons-compress, spring-web, parsson: removed because the nested dependency is now up to date
- spring-boot: left as-is because the dependency is still out of date
- protobuf-java: added to address a dependabot alert because the dependency is still out of date

Dependencies list from a "pure" build (with all dependencyManagement removed):
[76_deps.txt](https://github.com/user-attachments/files/17905645/76_deps.txt)

## Testing guidance
Everything in g10 should pass with the same results as before. 

Note: clearing out the DB and reloading resources from file does not appear to be strictly required, but I would recommend doing that anyway