### PR TITLE
Change Task from CDex conformant to PAS

### DIFF
--- a/resources/dtr_bundle_patient_pat015.json
+++ b/resources/dtr_bundle_patient_pat015.json
@@ -12,9 +12,9 @@
           {
             "use": "home",
             "type": "both",
-            "state": "MA",
-            "city": "Bedford",
-            "postalCode": "01730",
+            "state": "NY",
+            "city": "Buffalo",
+            "postalCode": "14210",
             "line": ["202 Burlington Road"]
           }
         ],
@@ -1355,7 +1355,7 @@
         ],
         "insurance": [
           {
-            "reference": "Coverage/cov016"
+            "reference": "Coverage/cov015"
           }
         ]
       },
@@ -1440,7 +1440,7 @@
                               {
                                 "url": "practitioner",
                                 "valueReference": {
-                                  "reference": "Practitioner/PractitionerExample",
+                                  "reference": "Practitioner/pra1234",
                                   "display": "Dr. Jane Doe"
                                 }
                               }
@@ -1674,7 +1674,7 @@
                               {
                                 "url": "practitioner",
                                 "valueReference": {
-                                  "reference": "Practitioner/PractitionerExample",
+                                  "reference": "Practitioner/pra1234",
                                   "display": "Dr. Jane Doe"
                                 }
                               }
@@ -2107,7 +2107,7 @@
     {
       "resource": {
         "resourceType": "CommunicationRequest",
-        "id": "communicationrequest-example1",
+        "id": "comreq015",
         "identifier": [
           {
             "system": "http://www.jurisdiction.com/insurer/123456",
@@ -2189,13 +2189,13 @@
       },
       "request": {
         "method": "PUT",
-        "url": "CommunicationRequest/communicationrequest-example1"
+        "url": "CommunicationRequest/comreq015"
       }
     },
     {
       "resource": {
         "resourceType": "MedicationRequest",
-        "id": "medicationrequest-example1",
+        "id": "medreq015",
         "contained": [
           {
             "resourceType": "Medication",
@@ -2399,13 +2399,13 @@
       },
       "request": {
         "method": "PUT",
-        "url": "MedicationRequest/medicationrequest-example1"
+        "url": "MedicationRequest/medreq015"
       }
     },
     {
       "resource": {
         "resourceType": "NutritionOrder",
-        "id": "nutritionorder-example1",
+        "id": "nutord015",
         "identifier": [
           {
             "system": "http://goodhealthhospital.org/nutrition-requests",
@@ -2426,7 +2426,7 @@
         },
         "allergyIntolerance": [
           {
-            "reference": "AllergyIntolerance/allergyintolerance-example1",
+            "reference": "AllergyIntolerance/allint015",
             "display": "Cashew Nuts"
           }
         ],
@@ -2509,13 +2509,13 @@
       },
       "request": {
         "method": "PUT",
-        "url": "NutritionOrder/nutritionorder-example1"
+        "url": "NutritionOrder/nutord015"
       }
     },
     {
       "resource": {
         "resourceType": "Task",
-        "id": "AdditionalInformationTaskExample",
+        "id": "tas015",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-task"
@@ -2561,7 +2561,7 @@
           ]
         },
         "reasonReference": {
-          "reference": "Claim/MedicalServicesAuthorizationExample"
+          "reference": "Claim/cla015"
         },
         "input": [
           {
@@ -2603,21 +2603,17 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Task/AdditionalInformationTaskExample"
+        "url": "Task/tas015"
       }
     },
     {
       "resource": {
         "resourceType": "Claim",
-        "id": "MedicalServicesAuthorizationExample",
+        "id": "cla015",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-claim"
           ]
-        },
-        "text": {
-          "status": "extensions",
-          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>Generated Narrative: Claim MedicalServicesAuthorizationExample</b></p><a name=\"MedicalServicesAuthorizationExample\"> </a><a name=\"hcMedicalServicesAuthorizationExample\"> </a><a name=\"MedicalServicesAuthorizationExample-en-US\"> </a><p><b>identifier</b>: <code>http://example.org/PATIENT_EVENT_TRACE_NUMBER</code>/111099</p><p><b>status</b>: Active</p><p><b>type</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/claim-type professional}\">Professional</span></p><p><b>use</b>: Preauthorization</p><p><b>patient</b>: <a href=\"Patient-SubscriberExample.html\">JOE SMITH  Male, DoB Unknown ( Member Number)</a></p><p><b>created</b>: 2005-05-02 11:01:00+0500</p><p><b>insurer</b>: <a href=\"Organization-InsurerExample.html\">Organization MARYLAND CAPITAL INSURANCE COMPANY</a></p><p><b>provider</b>: <a href=\"Organization-UMOExample.html\">Organization DR. JOE SMITH CORPORATION</a></p><p><b>priority</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/processpriority normal}\">Normal</span></p><h3>Insurances</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Sequence</b></td><td><b>Focal</b></td><td><b>Coverage</b></td></tr><tr><td style=\"display: none\">*</td><td>1</td><td>true</td><td><a href=\"Coverage-InsuranceExample.html\">Coverage: status = active; subscriberId = 1122334455; relationship = Self</a></td></tr></table><blockquote><p><b>item</b></p><p><b>ServiceItemRequestType</b>: <span title=\"Codes:{https://codesystem.x12.org/005010/1525 IN}\">Initial Medical Services Reservation</span></p><p><b>CertificationType</b>: <span title=\"Codes:{https://codesystem.x12.org/005010/1322 I}\">Initial</span></p><p><b>AuthorizationNumber</b>: 1122344</p><p><b>AdministrationReferenceNumber</b>: 33441122</p><p><b>sequence</b>: 1</p><p><b>category</b>: <span title=\"Codes:{https://codesystem.x12.org/005010/1365 1}\">Medical Care</span></p><p><b>productOrService</b>: <span title=\"Codes:{http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets 99212}\">Established Office Visit</span></p><p><b>serviced</b>: 2005-05-10</p><p><b>location</b>: <span title=\"Codes:{https://www.cms.gov/Medicare/Coding/place-of-service-codes/Place_of_Service_Code_Set 11}\">11</span></p></blockquote></div>"
         },
         "identifier": [
           {
@@ -2642,14 +2638,14 @@
         },
         "use": "preauthorization",
         "patient": {
-          "reference": "Patient/SubscriberExample"
+          "reference": "Patient/pat015"
         },
         "created": "2005-05-02T11:01:00+05:00",
         "insurer": {
-          "reference": "Organization/InsurerExample"
+          "reference": "Organization/org5678"
         },
         "provider": {
-          "reference": "Organization/UMOExample"
+          "reference": "Organization/org1234"
         },
         "priority": {
           "coding": [
@@ -2737,13 +2733,13 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Claim/MedicalServicesAuthorizationExample"
+        "url": "Claim/cla015"
       }
     },
     {
       "resource": {
         "resourceType": "Organization",
-        "id": "InsurerExample",
+        "id": "org5678",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-insurer"
@@ -2770,21 +2766,17 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Organization/InsurerExample"
+        "url": "Organization/5678"
       }
     },
     {
       "resource": {
         "resourceType": "Organization",
-        "id": "UMOExample",
+        "id": "org1234",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-requestor"
           ]
-        },
-        "text": {
-          "status": "generated",
-          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>Generated Narrative: Organization UMOExample</b></p><a name=\"UMOExample\"> </a><a name=\"hcUMOExample\"> </a><a name=\"UMOExample-en-US\"> </a><p><b>identifier</b>: <a href=\"http://terminology.hl7.org/6.0.2/NamingSystem-npi.html\" title=\"National Provider Identifier\">United States National Provider Identifier</a>/8189991234</p><p><b>active</b>: true</p><p><b>type</b>: <span title=\"Codes:{https://codesystem.x12.org/005010/98 X3}\">X3</span></p><p><b>name</b>: DR. JOE SMITH CORPORATION</p><p><b>address</b>: 111 1ST STREET SAN DIEGO CA 92101 US </p></div>"
         },
         "identifier": [
           {
@@ -2803,26 +2795,26 @@
             ]
           }
         ],
-        "name": "DR. JOE SMITH CORPORATION",
+        "name": "DR. JANE DOE CORPORATION",
         "address": [
           {
-            "line": ["111 1ST STREET"],
-            "city": "SAN DIEGO",
-            "state": "CA",
-            "postalCode": "92101",
+            "line": ["840 Seneca St"],
+            "city": "Buffalo",
+            "state": "NY",
+            "postalCode": "14210",
             "country": "US"
           }
         ]
       },
       "request": {
         "method": "PUT",
-        "url": "Organization/UMOExample"
+        "url": "Organization/org1234"
       }
     },
     {
       "resource": {
         "resourceType": "VisionPrescription",
-        "id": "visionprescription-example1",
+        "id": "visionprescription0151",
         "identifier": [
           {
             "system": "http://www.happysight.com/prescription",
@@ -2883,13 +2875,13 @@
       },
       "request": {
         "method": "PUT",
-        "url": "VisionPrescription/visionprescription-example1"
+        "url": "VisionPrescription/visionprescription0151"
       }
     },
     {
       "resource": {
         "resourceType": "VisionPrescription",
-        "id": "visionprescription-example2",
+        "id": "visionprescription0152",
         "identifier": [
           {
             "system": "http://www.happysight.com/prescription",
@@ -2950,13 +2942,13 @@
       },
       "request": {
         "method": "PUT",
-        "url": "VisionPrescription/visionprescription-example2"
+        "url": "VisionPrescription/visionprescription0152"
       }
     },
     {
       "resource": {
         "resourceType": "AllergyIntolerance",
-        "id": "allergyintolerance-example1",
+        "id": "allint015",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance"
@@ -3014,7 +3006,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "AllergyIntolerance/allergyintolerance-example1"
+        "url": "AllergyIntolerance/allint015"
       }
     }
   ],

--- a/resources/dtr_bundle_patient_pat015.json
+++ b/resources/dtr_bundle_patient_pat015.json
@@ -488,7 +488,6 @@
           },
           {
             "reference": "Organization/org1234",
-            "display": "Gulf Coast Lab",
             "type": "Organization"
           }
         ],
@@ -557,7 +556,6 @@
         "performer": [
           {
             "reference": "Organization/org1234",
-            "display": "Gulf Coast Lab",
             "type": "Organization"
           }
         ]
@@ -630,7 +628,6 @@
           },
           {
             "reference": "Organization/org1234",
-            "display": "Gulf Coast Lab",
             "type": "Organization"
           }
         ]
@@ -688,7 +685,6 @@
           },
           {
             "reference": "Organization/org1234",
-            "display": "Gulf Coast Lab",
             "type": "Organization"
           }
         ]
@@ -971,7 +967,6 @@
           },
           {
             "reference": "Organization/org1234",
-            "display": "Gulf Coast Lab",
             "type": "Organization"
           }
         ],
@@ -1045,7 +1040,6 @@
           },
           {
             "reference": "Organization/org1234",
-            "display": "Gulf Coast Lab",
             "type": "Organization"
           }
         ]

--- a/resources/dtr_bundle_patient_pat015.json
+++ b/resources/dtr_bundle_patient_pat015.json
@@ -2814,7 +2814,7 @@
     {
       "resource": {
         "resourceType": "VisionPrescription",
-        "id": "visionprescription0151",
+        "id": "vispre0151",
         "identifier": [
           {
             "system": "http://www.happysight.com/prescription",
@@ -2875,13 +2875,13 @@
       },
       "request": {
         "method": "PUT",
-        "url": "VisionPrescription/visionprescription0151"
+        "url": "VisionPrescription/vispre0151"
       }
     },
     {
       "resource": {
         "resourceType": "VisionPrescription",
-        "id": "visionprescription0152",
+        "id": "vispre0152",
         "identifier": [
           {
             "system": "http://www.happysight.com/prescription",
@@ -2942,7 +2942,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "VisionPrescription/visionprescription0152"
+        "url": "VisionPrescription/vispre0152"
       }
     },
     {

--- a/resources/dtr_bundle_patient_pat015.json
+++ b/resources/dtr_bundle_patient_pat015.json
@@ -2618,11 +2618,11 @@
         },
         "identifier": [
           {
-            "system": "http://example.org/PATIENT_EVENT_TRACE_NUMBER",
+            "system": "http://inferno.healthit.gov/reference-server/r4/PATIENT_EVENT_TRACE_NUMBER",
             "value": "111099",
             "assigner": {
               "identifier": {
-                "system": "http://example.org/USER_ASSIGNED",
+                "system": "http://inferno.healthit.gov/reference-server/r4/USER_ASSIGNED",
                 "value": "9012345678"
               }
             }

--- a/resources/dtr_bundle_patient_pat015.json
+++ b/resources/dtr_bundle_patient_pat015.json
@@ -399,7 +399,7 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:9dea2274-99b6-4bf9-ba97-60bd14be78ee",
+      "fullUrl": "DeviceRequest/devreq-015-e0250",
       "resource": {
         "resourceType": "DeviceRequest",
         "id": "devreq-015-e0250",
@@ -437,11 +437,11 @@
       },
       "request": {
         "method": "POST",
-        "url": "DeviceRequest/devreq-015-e0250"
+        "url": "DeviceRequest"
       }
     },
     {
-      "fullUrl": "urn:uuid:94675047-e98c-4f55-a450-bc9ae4aa7b1c",
+      "fullUrl": "Observation/obs015-hco3",
       "resource": {
         "resourceType": "Observation",
         "id": "obs015-hco3",
@@ -511,11 +511,11 @@
       },
       "request": {
         "method": "POST",
-        "url": "Observation/obs015-hco3"
+        "url": "Observation"
       }
     },
     {
-      "fullUrl": "urn:uuid:a127290b-e1fb-4e4a-96bf-f87d4d2de0a0",
+      "fullUrl": "Observation/obs015-o2sat-overnight",
       "resource": {
         "resourceType": "Observation",
         "id": "obs015-o2sat-overnight",
@@ -564,11 +564,11 @@
       },
       "request": {
         "method": "POST",
-        "url": "Observation/obs015-o2sat-overnight"
+        "url": "Observation"
       }
     },
     {
-      "fullUrl": "urn:uuid:e0d9292e-877f-47ce-849b-55f1d4b5de7c",
+      "fullUrl": "Observation/obs015-o2sat-resting",
       "resource": {
         "resourceType": "Observation",
         "id": "obs015-o2sat-resting",
@@ -637,11 +637,11 @@
       },
       "request": {
         "method": "POST",
-        "url": "Observation/obs015-o2sat-resting"
+        "url": "Observation"
       }
     },
     {
-      "fullUrl": "urn:uuid:a3b3ce04-24f4-46b0-943b-3b556a5a4dfb",
+      "fullUrl": "Observation/obs015-o2sat-treatment",
       "resource": {
         "resourceType": "Observation",
         "id": "obs015-o2sat-treatment",
@@ -695,11 +695,11 @@
       },
       "request": {
         "method": "POST",
-        "url": "Observation/obs015-o2sat-treatment"
+        "url": "Observation"
       }
     },
     {
-      "fullUrl": "urn:uuid:6acbaa05-2508-488e-afc0-b52a5e53ae57",
+      "fullUrl": "Observation/obs-pat015-pao2",
       "resource": {
         "resourceType": "Observation",
         "id": "obs-pat015-pao2",
@@ -766,11 +766,11 @@
       },
       "request": {
         "method": "POST",
-        "url": "Observation/obs-pat015-pao2"
+        "url": "Observation"
       }
     },
     {
-      "fullUrl": "urn:uuid:38470ed9-003b-47b9-bcf6-2e471a28e9ba",
+      "fullUrl": "Observation/obs-pat015-o2excercise",
       "resource": {
         "resourceType": "Observation",
         "id": "obs-pat015-o2excercise",
@@ -843,11 +843,11 @@
       },
       "request": {
         "method": "POST",
-        "url": "Observation/obs-pat015-o2excercise"
+        "url": "Observation"
       }
     },
     {
-      "fullUrl": "urn:uuid:4d9d1e76-3c37-4bff-8de0-2bbc01da4b54",
+      "fullUrl": "Observation/obs015",
       "resource": {
         "resourceType": "Observation",
         "id": "obs015",
@@ -920,11 +920,11 @@
       },
       "request": {
         "method": "POST",
-        "url": "Observation/obs015"
+        "url": "Observation"
       }
     },
     {
-      "fullUrl": "urn:uuid:b6a7ac74-a637-4040-87b6-4763de5a73bb",
+      "fullUrl": "Observation/obs015-paco2",
       "resource": {
         "resourceType": "Observation",
         "id": "obs015-paco2",
@@ -994,11 +994,11 @@
       },
       "request": {
         "method": "POST",
-        "url": "Observation/obs015-paco2"
+        "url": "Observation"
       }
     },
     {
-      "fullUrl": "urn:uuid:ae8690bb-520b-43f0-92cb-db07767b9dd5",
+      "fullUrl": "Observation/obs015-ph",
       "resource": {
         "resourceType": "Observation",
         "id": "obs015-ph",
@@ -1052,11 +1052,11 @@
       },
       "request": {
         "method": "POST",
-        "url": "Observation/obs015-ph"
+        "url": "Observation"
       }
     },
     {
-      "fullUrl": "urn:uuid:8a5c465a-b8b8-423d-a73c-949e71263bd6",
+      "fullUrl": "Observation/obs015B",
       "resource": {
         "resourceType": "Observation",
         "id": "obs015B",
@@ -1122,11 +1122,11 @@
       },
       "request": {
         "method": "POST",
-        "url": "Observation/obs015B"
+        "url": "Observation"
       }
     },
     {
-      "fullUrl": "urn:uuid:a30e788c-1773-49eb-a4d3-5b6d6fc46a61",
+      "fullUrl": "Observation/pat015-hemocrit",
       "resource": {
         "resourceType": "Observation",
         "id": "pat015-hemocrit",
@@ -1165,11 +1165,11 @@
       },
       "request": {
         "method": "POST",
-        "url": "Observation/pat015-hemocrit"
+        "url": "Observation"
       }
     },
     {
-      "fullUrl": "urn:uuid:9bdbafaa-d50d-4a45-9406-ea90058a1c49",
+      "fullUrl": "Condition/cond015a",
       "resource": {
         "resourceType": "Condition",
         "id": "cond015a",
@@ -1217,11 +1217,11 @@
       },
       "request": {
         "method": "POST",
-        "url": "Condition/cond015a"
+        "url": "Condition"
       }
     },
     {
-      "fullUrl": "urn:uuid:8deed1d5-dbc9-4ca9-b0a8-6c5464cb542f",
+      "fullUrl": "Condition/cond015b",
       "resource": {
         "resourceType": "Condition",
         "id": "cond015b",
@@ -1269,11 +1269,11 @@
       },
       "request": {
         "method": "POST",
-        "url": "Condition/cond015b"
+        "url": "Condition"
       }
     },
     {
-      "fullUrl": "urn:uuid:f6fcbaea-df5f-4a7e-93b6-1dd66534006c",
+      "fullUrl": "Condition/cond015c",
       "resource": {
         "resourceType": "Condition",
         "id": "cond015c",
@@ -1321,7 +1321,7 @@
       },
       "request": {
         "method": "POST",
-        "url": "Condition/cond015c"
+        "url": "Condition"
       }
     },
     {
@@ -1365,6 +1365,7 @@
       }
     },
     {
+      "fullUrl": "QuestionnaireResponse/queres015",
       "resource": {
         "resourceType": "QuestionnaireResponse",
         "id": "queres015",
@@ -2101,7 +2102,7 @@
       },
       "request": {
         "method": "POST",
-        "url": "QuestionnaireResponse/queres015"
+        "url": "QuestionnaireResponse"
       }
     },
     {
@@ -2737,6 +2738,7 @@
       }
     },
     {
+      "fullUrl": "Organization/org5678",
       "resource": {
         "resourceType": "Organization",
         "id": "org5678",
@@ -2766,7 +2768,7 @@
       },
       "request": {
         "method": "POST",
-        "url": "Organization/org5678"
+        "url": "Organization"
       }
     },
     {
@@ -2946,6 +2948,7 @@
       }
     },
     {
+      "fullUrl": "AllergyIntolerance/allint015",
       "resource": {
         "resourceType": "AllergyIntolerance",
         "id": "allint015",
@@ -3006,7 +3009,7 @@
       },
       "request": {
         "method": "POST",
-        "url": "AllergyIntolerance/allint015"
+        "url": "AllergyIntolerance"
       }
     }
   ],

--- a/resources/dtr_bundle_patient_pat015.json
+++ b/resources/dtr_bundle_patient_pat015.json
@@ -2608,6 +2608,256 @@
     },
     {
       "resource": {
+        "resourceType": "Claim",
+        "id": "MedicalServicesAuthorizationExample",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-claim"
+          ]
+        },
+        "text": {
+          "status": "extensions",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>Generated Narrative: Claim MedicalServicesAuthorizationExample</b></p><a name=\"MedicalServicesAuthorizationExample\"> </a><a name=\"hcMedicalServicesAuthorizationExample\"> </a><a name=\"MedicalServicesAuthorizationExample-en-US\"> </a><p><b>identifier</b>: <code>http://example.org/PATIENT_EVENT_TRACE_NUMBER</code>/111099</p><p><b>status</b>: Active</p><p><b>type</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/claim-type professional}\">Professional</span></p><p><b>use</b>: Preauthorization</p><p><b>patient</b>: <a href=\"Patient-SubscriberExample.html\">JOE SMITH  Male, DoB Unknown ( Member Number)</a></p><p><b>created</b>: 2005-05-02 11:01:00+0500</p><p><b>insurer</b>: <a href=\"Organization-InsurerExample.html\">Organization MARYLAND CAPITAL INSURANCE COMPANY</a></p><p><b>provider</b>: <a href=\"Organization-UMOExample.html\">Organization DR. JOE SMITH CORPORATION</a></p><p><b>priority</b>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/processpriority normal}\">Normal</span></p><h3>Insurances</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Sequence</b></td><td><b>Focal</b></td><td><b>Coverage</b></td></tr><tr><td style=\"display: none\">*</td><td>1</td><td>true</td><td><a href=\"Coverage-InsuranceExample.html\">Coverage: status = active; subscriberId = 1122334455; relationship = Self</a></td></tr></table><blockquote><p><b>item</b></p><p><b>ServiceItemRequestType</b>: <span title=\"Codes:{https://codesystem.x12.org/005010/1525 IN}\">Initial Medical Services Reservation</span></p><p><b>CertificationType</b>: <span title=\"Codes:{https://codesystem.x12.org/005010/1322 I}\">Initial</span></p><p><b>AuthorizationNumber</b>: 1122344</p><p><b>AdministrationReferenceNumber</b>: 33441122</p><p><b>sequence</b>: 1</p><p><b>category</b>: <span title=\"Codes:{https://codesystem.x12.org/005010/1365 1}\">Medical Care</span></p><p><b>productOrService</b>: <span title=\"Codes:{http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets 99212}\">Established Office Visit</span></p><p><b>serviced</b>: 2005-05-10</p><p><b>location</b>: <span title=\"Codes:{https://www.cms.gov/Medicare/Coding/place-of-service-codes/Place_of_Service_Code_Set 11}\">11</span></p></blockquote></div>"
+        },
+        "identifier": [
+          {
+            "system": "http://example.org/PATIENT_EVENT_TRACE_NUMBER",
+            "value": "111099",
+            "assigner": {
+              "identifier": {
+                "system": "http://example.org/USER_ASSIGNED",
+                "value": "9012345678"
+              }
+            }
+          }
+        ],
+        "status": "active",
+        "type": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/claim-type",
+              "code": "professional"
+            }
+          ]
+        },
+        "use": "preauthorization",
+        "patient": {
+          "reference": "Patient/SubscriberExample"
+        },
+        "created": "2005-05-02T11:01:00+05:00",
+        "insurer": {
+          "reference": "Organization/InsurerExample"
+        },
+        "provider": {
+          "reference": "Organization/UMOExample"
+        },
+        "priority": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/processpriority",
+              "code": "normal"
+            }
+          ]
+        },
+        "insurance": [
+          {
+            "sequence": 1,
+            "focal": true,
+            "coverage": {
+              "reference": "Coverage/InsuranceExample"
+            }
+          }
+        ],
+        "item": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-serviceItemRequestType",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://codesystem.x12.org/005010/1525",
+                      "code": "IN",
+                      "display": "Initial Medical Services Reservation"
+                    }
+                  ]
+                }
+              },
+              {
+                "url": "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-certificationType",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://codesystem.x12.org/005010/1322",
+                      "code": "I",
+                      "display": "Initial"
+                    }
+                  ]
+                }
+              },
+              {
+                "url": "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-authorizationNumber",
+                "valueString": "1122344"
+              },
+              {
+                "url": "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-administrationReferenceNumber",
+                "valueString": "33441122"
+              }
+            ],
+            "sequence": 1,
+            "category": {
+              "coding": [
+                {
+                  "system": "https://codesystem.x12.org/005010/1365",
+                  "code": "1",
+                  "display": "Medical Care"
+                }
+              ]
+            },
+            "productOrService": {
+              "coding": [
+                {
+                  "system": "http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets",
+                  "code": "99212",
+                  "display": "Established Office Visit"
+                }
+              ]
+            },
+            "servicedDate": "2005-05-10",
+            "locationCodeableConcept": {
+              "coding": [
+                {
+                  "system": "https://www.cms.gov/Medicare/Coding/place-of-service-codes/Place_of_Service_Code_Set",
+                  "code": "11"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Claim/MedicalServicesAuthorizationExample"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Coverage",
+        "id": "InsuranceExample",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-coverage"
+          ]
+        },
+        "status": "active",
+        "subscriberId": "1122334455",
+        "beneficiary": {
+          "reference": "Patient/pat015"
+        },
+        "relationship": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/subscriber-relationship",
+              "code": "self"
+            },
+            {
+              "system": "https://codesystem.x12.org/005010/1069",
+              "code": "18"
+            }
+          ]
+        },
+        "payor": [
+          {
+            "reference": "Organization/InsurerExample"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Coverage/InsuranceExample"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "InsurerExample",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-insurer"
+          ]
+        },
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "1234567893"
+          }
+        ],
+        "active": true,
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "https://codesystem.x12.org/005010/98",
+                "code": "PR"
+              }
+            ]
+          }
+        ],
+        "name": "MARYLAND CAPITAL INSURANCE COMPANY"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/InsurerExample"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "id": "UMOExample",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-requestor"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>Generated Narrative: Organization UMOExample</b></p><a name=\"UMOExample\"> </a><a name=\"hcUMOExample\"> </a><a name=\"UMOExample-en-US\"> </a><p><b>identifier</b>: <a href=\"http://terminology.hl7.org/6.0.2/NamingSystem-npi.html\" title=\"National Provider Identifier\">United States National Provider Identifier</a>/8189991234</p><p><b>active</b>: true</p><p><b>type</b>: <span title=\"Codes:{https://codesystem.x12.org/005010/98 X3}\">X3</span></p><p><b>name</b>: DR. JOE SMITH CORPORATION</p><p><b>address</b>: 111 1ST STREET SAN DIEGO CA 92101 US </p></div>"
+        },
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "8189991234"
+          }
+        ],
+        "active": true,
+        "type": [
+          {
+            "coding": [
+              {
+                "system": "https://codesystem.x12.org/005010/98",
+                "code": "X3"
+              }
+            ]
+          }
+        ],
+        "name": "DR. JOE SMITH CORPORATION",
+        "address": [
+          {
+            "line": ["111 1ST STREET"],
+            "city": "SAN DIEGO",
+            "state": "CA",
+            "postalCode": "92101",
+            "country": "US"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Organization/UMOExample"
+      }
+    },
+    {
+      "resource": {
         "resourceType": "VisionPrescription",
         "id": "visionprescription-example1",
         "identifier": [

--- a/resources/dtr_bundle_patient_pat015.json
+++ b/resources/dtr_bundle_patient_pat015.json
@@ -2515,81 +2515,16 @@
     {
       "resource": {
         "resourceType": "Task",
-        "id": "cdex-task-example19",
+        "id": "AdditionalInformationTaskExample",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/davinci-cdex/StructureDefinition/cdex-task-attachment-request"
+            "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-task"
           ]
         },
-        "contained": [
-          {
-            "resourceType": "Patient",
-            "id": "patient",
-            "meta": {
-              "profile": [
-                "http://hl7.org/fhir/us/davinci-cdex/StructureDefinition/cdex-patient-demographics"
-              ]
-            },
-            "identifier": [
-              {
-                "use": "usual",
-                "type": {
-                  "coding": [
-                    {
-                      "system": "http://hl7.org/fhir/us/davinci-hrex/CodeSystem/hrex-temp",
-                      "code": "UMB"
-                    }
-                  ],
-                  "text": "Member Number"
-                },
-                "system": "http://inferno.healthit.gov/reference-server/r4/cdex/payer/member-ids",
-                "value": "Member123"
-              }
-            ],
-            "name": [
-              {
-                "family": "Shaw",
-                "given": ["Amy"]
-              }
-            ],
-            "birthDate": "1987-02-20"
-          },
-          {
-            "resourceType": "PractitionerRole",
-            "id": "practitionerrole",
-            "meta": {
-              "profile": [
-                "http://hl7.org/fhir/us/davinci-cdex/StructureDefinition/cdex-practitionerrole"
-              ]
-            },
-            "practitioner": {
-              "identifier": {
-                "system": "http://hl7.org/fhir/sid/us-npi",
-                "value": "9941339100"
-              }
-            },
-            "organization": {
-              "identifier": {
-                "system": "http://hl7.org/fhir/sid/us-npi",
-                "value": "1234567893"
-              }
-            }
-          }
-        ],
         "identifier": [
           {
-            "type": {
-              "coding": [
-                {
-                  "system": "http://hl7.org/fhir/us/davinci-cdex/CodeSystem/cdex-temp",
-                  "code": "tracking-id",
-                  "display": "Tracking Id"
-                }
-              ],
-              "text": "Re-Association Tracking Control Number"
-            },
-            "system": "http://inferno.healthit.gov/reference-server/r4/payer",
-            "value": "trackingid123"
+            "system": "http://inferno.healthit.gov/reference-server/r4/ITEM_TRACE_NUMBER",
+            "value": "1122334"
           }
         ],
         "status": "requested",
@@ -2597,60 +2532,61 @@
         "code": {
           "coding": [
             {
-              "system": "http://hl7.org/fhir/us/davinci-cdex/CodeSystem/cdex-temp",
+              "system": "http://hl7.org/fhir/us/davinci-pas/CodeSystem/PASTempCodes",
               "code": "attachment-request-code"
             }
-          ],
-          "text": "Coded Attachment Request"
+          ]
         },
         "for": {
-          "reference": "#patient"
+          "reference": "Patient/pat015"
         },
-        "authoredOn": "2022-06-17T16:16:06Z",
-        "lastModified": "2022-06-17T16:16:06Z",
         "requester": {
           "identifier": {
-            "system": "http://inferno.healthit.gov/reference-server/r4/cdex/payer/payer-ids",
-            "value": "Payer123"
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "789312"
           }
         },
         "owner": {
-          "reference": "#practitionerrole"
+          "identifier": {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "789312"
+          }
         },
         "reasonCode": {
           "coding": [
             {
-              "system": "http://hl7.org/fhir/claim-use",
-              "code": "claim",
-              "display": "Claim"
+              "system": "http://hl7.org/fhir/us/davinci-pas/CodeSystem/PASTempCodes",
+              "code": "priorAuthorization"
             }
-          ],
-          "text": "claim"
+          ]
         },
         "reasonReference": {
-          "identifier": {
-            "system": "http://inferno.healthit.gov/r4/reference-server/r4/cdex/payer/claim-ids",
-            "value": "Claim123"
-          }
-        },
-        "restriction": {
-          "period": {
-            "end": "2022-06-21"
-          }
+          "reference": "Claim/MedicalServicesAuthorizationExample"
         },
         "input": [
           {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/us/davinci-pas/CodeSystem/PASTempCodes",
+                  "code": "payer-url"
+                }
+              ]
+            },
+            "valueUrl": "http://inferno.healthit.gov/reference-server/r4/payerURL"
+          },
+          {
             "extension": [
               {
-                "url": "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-serviceLineNumber",
-                "valuePositiveInt": 1
+                "url": "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-paLineNumber",
+                "valueInteger": 1
               }
             ],
             "type": {
               "coding": [
                 {
-                  "system": "http://hl7.org/fhir/us/davinci-hrex/CodeSystem/hrex-temp",
-                  "code": "data-code"
+                  "system": "http://hl7.org/fhir/us/davinci-pas/CodeSystem/PASTempCodes",
+                  "code": "attachments-needed"
                 }
               ]
             },
@@ -2658,61 +2594,7 @@
               "coding": [
                 {
                   "system": "http://loinc.org",
-                  "code": "11506-3",
-                  "display": "Progress note"
-                }
-              ],
-              "text": "Progress note"
-            }
-          },
-          {
-            "type": {
-              "coding": [
-                {
-                  "system": "http://hl7.org/fhir/us/davinci-cdex/CodeSystem/cdex-temp",
-                  "code": "signature-flag"
-                }
-              ]
-            },
-            "valueBoolean": true
-          },
-          {
-            "type": {
-              "coding": [
-                {
-                  "system": "http://hl7.org/fhir/us/davinci-cdex/CodeSystem/cdex-temp",
-                  "code": "payer-url"
-                }
-              ]
-            },
-            "valueUrl": "http://inferno.healthit.gov/reference-server/r4/cdex/payer/$submit-attachment"
-          },
-          {
-            "type": {
-              "coding": [
-                {
-                  "system": "http://hl7.org/fhir/us/davinci-cdex/CodeSystem/cdex-temp",
-                  "code": "service-date"
-                }
-              ]
-            },
-            "valueDate": "2022-06-13"
-          },
-          {
-            "type": {
-              "coding": [
-                {
-                  "system": "http://hl7.org/fhir/us/davinci-cdex/CodeSystem/cdex-temp",
-                  "code": "purpose-of-use"
-                }
-              ]
-            },
-            "valueCodeableConcept": {
-              "coding": [
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason",
-                  "code": "CLMATTCH",
-                  "display": "claim attachment"
+                  "code": "26443-2"
                 }
               ]
             }
@@ -2721,7 +2603,7 @@
       },
       "request": {
         "method": "PUT",
-        "url": "Task/cdex-task-example19"
+        "url": "Task/AdditionalInformationTaskExample"
       }
     },
     {

--- a/resources/dtr_bundle_patient_pat015.json
+++ b/resources/dtr_bundle_patient_pat015.json
@@ -436,7 +436,7 @@
         }
       },
       "request": {
-        "method": "PUT",
+        "method": "POST",
         "url": "DeviceRequest/devreq-015-e0250"
       }
     },
@@ -510,7 +510,7 @@
         ]
       },
       "request": {
-        "method": "PUT",
+        "method": "POST",
         "url": "Observation/obs015-hco3"
       }
     },
@@ -563,7 +563,7 @@
         ]
       },
       "request": {
-        "method": "PUT",
+        "method": "POST",
         "url": "Observation/obs015-o2sat-overnight"
       }
     },
@@ -636,7 +636,7 @@
         ]
       },
       "request": {
-        "method": "PUT",
+        "method": "POST",
         "url": "Observation/obs015-o2sat-resting"
       }
     },
@@ -694,7 +694,7 @@
         ]
       },
       "request": {
-        "method": "PUT",
+        "method": "POST",
         "url": "Observation/obs015-o2sat-treatment"
       }
     },
@@ -765,7 +765,7 @@
         ]
       },
       "request": {
-        "method": "PUT",
+        "method": "POST",
         "url": "Observation/obs-pat015-pao2"
       }
     },
@@ -842,7 +842,7 @@
         ]
       },
       "request": {
-        "method": "PUT",
+        "method": "POST",
         "url": "Observation/obs-pat015-o2excercise"
       }
     },
@@ -919,7 +919,7 @@
         ]
       },
       "request": {
-        "method": "PUT",
+        "method": "POST",
         "url": "Observation/obs015"
       }
     },
@@ -993,7 +993,7 @@
         ]
       },
       "request": {
-        "method": "PUT",
+        "method": "POST",
         "url": "Observation/obs015-paco2"
       }
     },
@@ -1051,7 +1051,7 @@
         ]
       },
       "request": {
-        "method": "PUT",
+        "method": "POST",
         "url": "Observation/obs015-ph"
       }
     },
@@ -1121,7 +1121,7 @@
         ]
       },
       "request": {
-        "method": "PUT",
+        "method": "POST",
         "url": "Observation/obs015B"
       }
     },
@@ -1164,7 +1164,7 @@
         }
       },
       "request": {
-        "method": "PUT",
+        "method": "POST",
         "url": "Observation/pat015-hemocrit"
       }
     },
@@ -1216,7 +1216,7 @@
         }
       },
       "request": {
-        "method": "PUT",
+        "method": "POST",
         "url": "Condition/cond015a"
       }
     },
@@ -1268,7 +1268,7 @@
         }
       },
       "request": {
-        "method": "PUT",
+        "method": "POST",
         "url": "Condition/cond015b"
       }
     },
@@ -1320,7 +1320,7 @@
         }
       },
       "request": {
-        "method": "PUT",
+        "method": "POST",
         "url": "Condition/cond015c"
       }
     },
@@ -1367,7 +1367,7 @@
     {
       "resource": {
         "resourceType": "QuestionnaireResponse",
-        "id": "home-o2-questionnaireresponse",
+        "id": "queres015",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-questionnaireresponse"
@@ -2100,8 +2100,8 @@
         ]
       },
       "request": {
-        "method": "PUT",
-        "url": "QuestionnaireResponse/home-o2-questionnaireresponse"
+        "method": "POST",
+        "url": "QuestionnaireResponse/queres015"
       }
     },
     {
@@ -2762,11 +2762,11 @@
             ]
           }
         ],
-        "name": "MARYLAND CAPITAL INSURANCE COMPANY"
+        "name": "NEW YORK CAPITAL INSURANCE COMPANY"
       },
       "request": {
-        "method": "PUT",
-        "url": "Organization/5678"
+        "method": "POST",
+        "url": "Organization/org5678"
       }
     },
     {
@@ -3005,7 +3005,7 @@
         ]
       },
       "request": {
-        "method": "PUT",
+        "method": "POST",
         "url": "AllergyIntolerance/allint015"
       }
     }

--- a/resources/dtr_bundle_patient_pat015.json
+++ b/resources/dtr_bundle_patient_pat015.json
@@ -303,7 +303,7 @@
         "status": "draft",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-devicerequest-r4"
+            "http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-devicerequest"
           ]
         },
         "insurance": [
@@ -350,7 +350,7 @@
         "id": "devreq015",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/davinci-crd/R4/StructureDefinition/profile-devicerequest-r4"
+            "http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-devicerequest"
           ]
         },
         "insurance": [
@@ -405,7 +405,7 @@
         "id": "devreq-015-e0250",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/davinci-crd/R4/StructureDefinition/profile-devicerequest-r4"
+            "http://hl7.org/fhir/us/davinci-crd/StructureDefinition/profile-devicerequest"
           ]
         },
         "insurance": [

--- a/resources/dtr_bundle_patient_pat015.json
+++ b/resources/dtr_bundle_patient_pat015.json
@@ -390,7 +390,7 @@
         },
         "authoredOn": "2023-01-01T00:00:00Z",
         "requester": {
-          "reference": "Practitioner/pra-hfairchild"
+          "reference": "Practitioner/pra1234"
         }
       },
       "request": {
@@ -432,7 +432,7 @@
         "authoredOn": "2023-01-01T00:00:00Z",
         "intent": "original-order",
         "requester": {
-          "reference": "Practitioner/pra-hfairchild"
+          "reference": "Practitioner/pra1234"
         }
       },
       "request": {
@@ -482,12 +482,12 @@
         },
         "performer": [
           {
-            "reference": "Practitioner/pra-dmorgan",
-            "display": "Dexter Morgan",
+            "reference": "Practitioner/pra1234",
+            "display": "Jane Doe",
             "type": "Practitioner"
           },
           {
-            "reference": "Organization/org-lab",
+            "reference": "Organization/org1234",
             "display": "Gulf Coast Lab",
             "type": "Organization"
           }
@@ -556,8 +556,8 @@
         },
         "performer": [
           {
-            "reference": "Organization/org-lab",
-            "display": "Clinical Lab",
+            "reference": "Organization/org1234",
+            "display": "Gulf Coast Lab",
             "type": "Organization"
           }
         ]
@@ -624,8 +624,8 @@
         },
         "performer": [
           {
-            "reference": "Practitioner/pra-dmorgan",
-            "display": "Dexter Morgan",
+            "reference": "Practitioner/pra1234",
+            "display": "Jane Doe",
             "type": "Practitioner"
           },
           {
@@ -682,8 +682,8 @@
         },
         "performer": [
           {
-            "reference": "Practitioner/pra-dmorgan",
-            "display": "Dexter Morgan",
+            "reference": "Practitioner/pra1234",
+            "display": "Jane Doe",
             "type": "Practitioner"
           },
           {
@@ -965,12 +965,12 @@
         },
         "performer": [
           {
-            "reference": "Practitioner/pra-dmorgan",
-            "display": "Dexter Morgan",
+            "reference": "Practitioner/pra1234",
+            "display": "Jane Doe",
             "type": "Practitioner"
           },
           {
-            "reference": "Organization/org-lab",
+            "reference": "Organization/org1234",
             "display": "Gulf Coast Lab",
             "type": "Organization"
           }
@@ -1039,12 +1039,12 @@
         },
         "performer": [
           {
-            "reference": "Practitioner/pra-dmorgan",
-            "display": "Dexter Morgan",
+            "reference": "Practitioner/pra1234",
+            "display": "Jane Doe",
             "type": "Practitioner"
           },
           {
-            "reference": "Organization/org-lab",
+            "reference": "Organization/org1234",
             "display": "Gulf Coast Lab",
             "type": "Organization"
           }
@@ -1350,7 +1350,7 @@
         },
         "performer": [
           {
-            "reference": "Practitioner/pra1255"
+            "reference": "Practitioner/pra1234"
           }
         ],
         "insurance": [

--- a/resources/dtr_bundle_patient_pat015.json
+++ b/resources/dtr_bundle_patient_pat015.json
@@ -2664,7 +2664,7 @@
             "sequence": 1,
             "focal": true,
             "coverage": {
-              "reference": "Coverage/InsuranceExample"
+              "reference": "Coverage/cov015"
             }
           }
         ],
@@ -2738,43 +2738,6 @@
       "request": {
         "method": "PUT",
         "url": "Claim/MedicalServicesAuthorizationExample"
-      }
-    },
-    {
-      "resource": {
-        "resourceType": "Coverage",
-        "id": "InsuranceExample",
-        "meta": {
-          "profile": [
-            "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-coverage"
-          ]
-        },
-        "status": "active",
-        "subscriberId": "1122334455",
-        "beneficiary": {
-          "reference": "Patient/pat015"
-        },
-        "relationship": {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/subscriber-relationship",
-              "code": "self"
-            },
-            {
-              "system": "https://codesystem.x12.org/005010/1069",
-              "code": "18"
-            }
-          ]
-        },
-        "payor": [
-          {
-            "reference": "Organization/InsurerExample"
-          }
-        ]
-      },
-      "request": {
-        "method": "PUT",
-        "url": "Coverage/InsuranceExample"
       }
     },
     {


### PR DESCRIPTION
# Summary
This PR changes the Task resource in the `dtr_bundle_patient_pat015.json` file from a CDex Task to a PAS Task. This is to reflect changes to the DTR Light EHR Test suite in the davinci-dtr-test-kit based on this PR comment: https://github.com/inferno-framework/davinci-dtr-test-kit/pull/35#discussion_r1868310626.

## New behavior
- Task is now conformant to the [PAS Task](http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-task) profile rather than the [CDex Task Profile](http://hl7.org/fhir/us/davinci-cdex/StructureDefinition/cdex-task-attachment-request).

## Code changes
- Example PAS Task from the [PAS IG](http://hl7.org/fhir/us/davinci-pas/STU2/Task-AdditionalInformationTaskExample.html) instead of CDex Task.

## Testing guidance
- Run this branch locally and run [this branch](https://github.com/inferno-framework/davinci-dtr-test-kit/pull/35) of the `davinci-dtr-test-kit` and run the DTR Light EHR Profiles Tests in the DTR Light EHR Test Suite using the Inferno Reference Server (Local) preset.