### PR TITLE
Update maven_ci.yml to use actions/cache@v4

### DIFF
--- a/.github/workflows/maven_ci.yml
+++ b/.github/workflows/maven_ci.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         java-version: 17
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
# Summary

According to [this error](https://github.com/inferno-framework/inferno-reference-server/actions/runs/13635434189/job/38112910279?pr=201) the action cache@v2 is now depreciated