### PR TITLE
FI-3646: Add CARIN and combo Groups

### DIFF
--- a/resources/carin_proxy_group_patient_888.json
+++ b/resources/carin_proxy_group_patient_888.json
@@ -1,0 +1,16 @@
+{
+  "resourceType": "Group",
+  "id": "carin-Group",
+  "active": true,
+  "type": "person",
+  "actual": true,
+  "name": "Proxy Group for patient Export",
+  "quantity": 1,
+  "member": [
+      {
+          "entity": {
+              "reference": "Patient/888"
+          }
+      }
+  ]
+}

--- a/resources/combo_proxy_group.json
+++ b/resources/combo_proxy_group.json
@@ -1,0 +1,31 @@
+{
+  "resourceType": "Group",
+  "id": "combo-Group",
+  "active": true,
+  "type": "person",
+  "actual": true,
+  "name": "Proxy Group for patient Export",
+  "quantity": 4,
+  "member": [
+    {
+      "entity": {
+          "reference": "Patient/888"
+      }
+    },
+    {
+      "entity": {
+          "reference": "Patient/999"
+      }
+    },
+    {
+      "entity": {
+          "reference": "Patient/85"
+      }
+    },
+    {
+      "entity": {
+          "reference": "Patient/355"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Summary
- Add a group for the CARIN patient (888)
- Add a "combo" group containing patients from CARIN, PDex, and US Core

## New behavior
Additional groups to support targeting bulk exports via Group method for specific IG data

## Code changes
resources/carin_proxy_group_patient_888.json
resources/combo_proxy_group.json