### PR TITLE
FI-3405: Add EOB:insurer SearchParameter from Carin4BB

### DIFF
--- a/resources/carin_2_1_SearchParameter-explanationofbenefit-insurer.json
+++ b/resources/carin_2_1_SearchParameter-explanationofbenefit-insurer.json
@@ -1,0 +1,51 @@
+{
+  "resourceType" : "SearchParameter",
+  "id" : "explanationofbenefit-insurer",
+  "meta" : {
+    "versionId" : "1",
+    "lastUpdated" : "2020-03-31T06:41:13.000+00:00"
+  },
+  "text" : {
+    "status" : "generated",
+    "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p class=\"res-header-id\"><b>Generated Narrative: SearchParameter explanationofbenefit-insurer</b></p><a name=\"explanationofbenefit-insurer\"> </a><a name=\"hcexplanationofbenefit-insurer\"> </a><a name=\"explanationofbenefit-insurer-en-US\"> </a><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">version: 1; Last updated: 2020-03-31 06:41:13+0000</p></div><h2>ExplanationOfBenefit_Insurer <a style=\"padding-left: 3px; padding-right: 3px; border: 1px grey solid; font-weight: bold; color: black; background-color: #fff5e6\" href=\"http://hl7.org/fhir/R4/versions.html#std-process\" title=\"Standards Status = Trial Use\">TU</a></h2><p>Parameter <code>insurer</code>:<code>reference</code></p><div><p>The party responsible for the claim</p>\n</div><table class=\"grid\"><tr><td>Resource</td><td><a href=\"http://hl7.org/fhir/R4/explanationofbenefit.html\">ExplanationOfBenefit</a></td></tr><tr><td>Expression</td><td><code>ExplanationOfBenefit.insurer</code></td></tr><tr><td>Processing Mode</td><td>Normal</td></tr><tr><td>Target Resources</td><td><a href=\"http://hl7.org/fhir/R4/organization.html\">Organization</a></td></tr><tr><td>Multiples</td><td><ul><li>multipleAnd: It's up to the server whether the parameter may repeat in order to specify multiple values that must all be true</li><li>multipleOr: It's up to the server whether the parameter can have multiple values (separated by comma) where at least one must be true</li></ul></td></tr></table></div>"
+  },
+  "extension" : [{
+    "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+    "valueCode" : "trial-use"
+  },
+  {
+    "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+    "valueCode" : "fm"
+  }],
+  "url" : "http://hl7.org/fhir/us/carin-bb/SearchParameter/explanationofbenefit-insurer",
+  "version" : "2.1.0",
+  "name" : "ExplanationOfBenefit_Insurer",
+  "status" : "active",
+  "experimental" : false,
+  "date" : "2020-03-31T09:48:45+00:00",
+  "publisher" : "HL7 International / Financial Management",
+  "contact" : [{
+    "name" : "HL7 International / Financial Management",
+    "telecom" : [{
+      "system" : "url",
+      "value" : "http://www.hl7.org/Special/committees/fm"
+    },
+    {
+      "system" : "email",
+      "value" : "fm@lists.HL7.org"
+    }]
+  }],
+  "description" : "The party responsible for the claim",
+  "jurisdiction" : [{
+    "coding" : [{
+      "system" : "urn:iso:std:iso:3166",
+      "code" : "US"
+    }]
+  }],
+  "code" : "insurer",
+  "base" : ["ExplanationOfBenefit"],
+  "type" : "reference",
+  "expression" : "ExplanationOfBenefit.insurer",
+  "xpathUsage" : "normal",
+  "target" : ["Organization"]
+}


### PR DESCRIPTION
# Summary
Adds the ExplanationOfBenefit:insurer SearchParameter from the Carin4BB IG. Note this comes from the latest (STU 2.1) version of the IG but functionally it's the same as the earlier versions.

## New behavior
Enables searches using the `insurer` parameter on ExplanationOfBenefit resource - both as a direct parameter eg `/ExplanationOfBenefit?insurer=123` or as an include parameter eg `/ExplanationOfBenefit?_include=ExplanationOfBenefit:insurer`

## Code changes
Just added the search param file to resources so it's loaded at startup.

## Testing guidance
Reset the DB and run the server to load the new resources. Run the following sample requests:
```
GET {BASE_URL}/ExplanationOfBenefit?_include=ExplanationOfBenefit:insurer&patient=888

GET {BASE_URL}/ExplanationOfBenefit?insurer=c4bb-Organization
```

Running against the prod instance, these will both return errors, but with the new search param loaded locally they will work and you can inspect the results to confirm they are correct. For the first one, the returned Bundle should include instances of Organization resources (at the end), and for the second one, the insurer field on all returned resources should match the provided ID.

See also test 2.3.13 in the Carin4BB test kit - it currently fails on prod ( https://inferno.healthit.gov/suites/c4bb_v200/bSHsLmOOR8w#2.3 ) but should now pass running against a local server.