### PR TITLE
Bump dependencies [dependabot]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <hapi.version>7.6.0</hapi.version>
-    <jetty_version>12.0.8</jetty_version>
+    <jetty_version>12.0.16</jetty_version>
     <checkstyle.plugin.version>3.3.1</checkstyle.plugin.version>
     <checkstyle.version>10.15.0</checkstyle.version>
     <checkstyle.config>config/checkstyle/checkstyle.xml</checkstyle.config>
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.5.5</version>
+      <version>1.5.17</version>
     </dependency>
 
     <!-- Required for JEE/Servlet support. -->
@@ -237,7 +237,7 @@
   -->
   <dependencyManagement>
     <dependencies>
-      <!-- nested dependency of hapi-fhir-jpaserver-base -->
+      <!-- nested dependencies of hapi-fhir-jpaserver-base -->
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot</artifactId>
@@ -248,6 +248,19 @@
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>3.25.5</version>
+      </dependency>
+
+      <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>json-smart</artifactId>
+        <version>2.5.2</version>
+      </dependency>
+
+      <!-- nested dependencies of hapi-fhir-jpaserver-model -->
+      <dependency>
+        <groupId>org.fhir</groupId>
+        <artifactId>ucum</artifactId>
+        <version>1.0.9</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
# Summary
Bumps a few direct and nested dependencies to address dependabot security alerts. Because of how these are defined in the pom, dependabot cannot create these PRs itself.


## Testing guidance
Run g10 or any other test kit against this and make sure nothing broke