### PR TITLE
FI-3996: Add client_id and exp to tokens generated for backend services

### DIFF
--- a/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
+++ b/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java
@@ -180,7 +180,9 @@ public class AuthorizationController {
 
     TokenManager tokenManager = TokenManager.getInstance();
     Token token = tokenManager.createToken(scopeString);
+    token.setClientId(clientId);
     int expiresIn = 300;
+    token.setExp(java.time.Instant.now().getEpochSecond() + expiresIn);
 
     JSONObject accessToken = new JSONObject();
     accessToken.put("token_type", "bearer");


### PR DESCRIPTION
# Summary
When running SMART test kit token introspection tests, the token introspection test fails because the response is missing the client_id field. This PR adds the `client_id` field to the internal Token model for tokens generated by backend services auth. The logic to report this field back out when set was already present, so no changes needed there. The `exp` field was also added, because that field is also required and missing but the error was obscured by the missing client_id. The logic to set exp was copied from elsewhere in the same file: https://github.com/inferno-framework/inferno-reference-server/blob/624dac3b239b4fc465f5b4f8825f3281a2469324/src/main/java/org/mitre/fhir/authorization/AuthorizationController.java#L468

## Testing guidance
On the SMART App Launch test kit, SMART v2.2:

1. Use the Inferno Reference Server preset
2. Run test group 3 "Backend Services" but change the FHIR Endpoint to point to your local running server eg `http://localhost:8080`
3. Capture the token from the request in test 3.2.05  ; see request Details > Response Body
4. Run test group 4.2 "Issue Token Introspection Request" - set the auth type = "backend services", set the token from the previous step, client ID = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InJlZ2lzdHJhdGlvbi10b2tlbiJ9.eyJqd2tzX3VybCI6Imh0dHA6Ly8xMC4xNS4yNTIuNzMvaW5mZXJuby8ud2VsbC1rbm93bi9qd2tzLmpzb24iLCJhY2Nlc3NUb2tlbnNFeHBpcmVJbiI6MTUsImlhdCI6MTU5NzQxMzE5NX0.q4v4Msc74kN506KTZ0q_minyapJw0gwlT6M_uiL73S4`
5. Run test group 4.3 "Validate Token Introspection Response" - set the "Expected Introspection Response Value: scope" to `system/*.read` 
6. All of the above tests should pass


All other tests should also pass as usual, for example in g10. If you want to load data, make sure to load the latest data either by using the docker-compose approach or by running the fetch_data_repo script, eg `SOURCE_DATA_REPO=http://github.com/inferno-framework/inferno-reference-server-data ./scripts/fetch_data_repo.sh`